### PR TITLE
feat(oasisopen-cosai): add CoSAI MCP Security framework

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3204,6 +3204,10 @@
       "resolved": "package/nz/hisf/v1",
       "link": true
     },
+    "node_modules/@zerobias-org/framework-oasisopen-cosai-mcp_security": {
+      "resolved": "package/oasisopen/cosai/mcp_security",
+      "link": true
+    },
     "node_modules/@zerobias-org/framework-opencre-opencre-update": {
       "resolved": "package/opencre/opencre/update",
       "link": true
@@ -3686,6 +3690,15 @@
         "@zerobias-org/vendor-nz": "latest"
       }
     },
+    "node_modules/@zerobias-org/suite-oasisopen-cosai": {
+      "version": "0.0.1",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/suite-oasisopen-cosai/-/suite-oasisopen-cosai-0.0.1.tgz",
+      "integrity": "sha512-qxuSqUsQRasFrO1zvlAXurAsl2YuQS9pL2oAVG7alcNh7T0MZ5nA0CnKamvWcc8dvwOiJfJ4QpuzWOHM2pwoYg==",
+      "license": "ISC",
+      "dependencies": {
+        "@zerobias-org/vendor-oasisopen": "latest"
+      }
+    },
     "node_modules/@zerobias-org/suite-opencre-opencre": {
       "version": "1.0.3",
       "resolved": "https://pkg.zerobias.org/@zerobias-org/suite-opencre-opencre/-/suite-opencre-opencre-1.0.3.tgz",
@@ -4033,6 +4046,12 @@
       "version": "1.0.4",
       "resolved": "https://pkg.zerobias.org/@zerobias-org/vendor-nz/-/vendor-nz-1.0.4.tgz",
       "integrity": "sha512-9401ZToG9We2/ttd0HgB8oo5/r623eytiZhwJi3n5v45LMXCzWxx35kpfuFKJN7PCxGMMd4bmLIP1rTZNf3x2g==",
+      "license": "ISC"
+    },
+    "node_modules/@zerobias-org/vendor-oasisopen": {
+      "version": "1.0.6",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/vendor-oasisopen/-/vendor-oasisopen-1.0.6.tgz",
+      "integrity": "sha512-Tc6R+42rgtDRfxecrtcb/b+3Y75C8/zzyaC+8yRpmW6TPXZFgdTnuQwi7rD4jTHeBMxKZB5jQJoiae/GKsr+LQ==",
       "license": "ISC"
     },
     "node_modules/@zerobias-org/vendor-opencre": {
@@ -12753,6 +12772,14 @@
       "license": "ISC",
       "dependencies": {
         "@zerobias-org/suite-nz-hisf": "latest"
+      }
+    },
+    "package/oasisopen/cosai/mcp_security": {
+      "name": "@zerobias-org/framework-oasisopen-cosai-mcp_security",
+      "version": "0.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@zerobias-org/suite-oasisopen-cosai": "latest"
       }
     },
     "package/opencre/opencre/update": {

--- a/package/oasisopen/cosai/mcp_security/.npmrc
+++ b/package/oasisopen/cosai/mcp_security/.npmrc
@@ -1,0 +1,2 @@
+@zerobias-org:registry=https://pkg.zerobias.org/
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/oasisopen/cosai/mcp_security/elements/c_3_2_1.yml
+++ b/package/oasisopen/cosai/mcp_security/elements/c_3_2_1.yml
@@ -1,0 +1,9 @@
+id: f6f2e846-fd4c-4fad-94af-3334a12ceb4b
+externalId: C-3.2.1
+name: Agent Identity
+description: >-
+  Establish and verify agent identity through robust authentication mechanisms
+  including OAuth 2.1 with PKCE, mutual TLS, or equivalent protocols. Ensure
+  MCP clients and servers can authenticate each other and maintain verifiable
+  identity chains across tool invocations.
+elementType: control

--- a/package/oasisopen/cosai/mcp_security/elements/c_3_2_10.yml
+++ b/package/oasisopen/cosai/mcp_security/elements/c_3_2_10.yml
@@ -1,0 +1,9 @@
+id: ec35102f-f3e5-4d19-a972-1988df22868a
+externalId: C-3.2.10
+name: Logging
+description: >-
+  Implement comprehensive logging for all MCP operations including tool
+  invocations, resource access, authentication events, and error conditions.
+  Ensure logs capture sufficient context for incident investigation, compliance
+  auditing, and anomaly detection in MCP-connected systems.
+elementType: control

--- a/package/oasisopen/cosai/mcp_security/elements/c_3_2_11.yml
+++ b/package/oasisopen/cosai/mcp_security/elements/c_3_2_11.yml
@@ -1,0 +1,9 @@
+id: 54a5d00e-f01d-4b29-b078-2e3badd9a26c
+externalId: C-3.2.11
+name: Lifecycle and Governance
+description: >-
+  Establish governance processes for the MCP server lifecycle including
+  vetting, approval, version management, deprecation, and decommissioning.
+  Implement policies for server registry management, update procedures,
+  and vulnerability response to maintain supply chain security.
+elementType: control

--- a/package/oasisopen/cosai/mcp_security/elements/c_3_2_2.yml
+++ b/package/oasisopen/cosai/mcp_security/elements/c_3_2_2.yml
@@ -1,0 +1,9 @@
+id: 9c7f2a03-aea3-41a1-8a6c-7e44d33f9727
+externalId: C-3.2.2
+name: Secure Delegation and Access Control
+description: >-
+  Implement fine-grained access control and secure delegation mechanisms for
+  MCP tool invocations. Enforce least-privilege principles, scope-based
+  permissions, and capability-based authorization to prevent privilege
+  escalation and unauthorized resource access.
+elementType: control

--- a/package/oasisopen/cosai/mcp_security/elements/c_3_2_3.yml
+++ b/package/oasisopen/cosai/mcp_security/elements/c_3_2_3.yml
@@ -1,0 +1,9 @@
+id: 4c036318-9d7d-4060-b212-211efd84ec06
+externalId: C-3.2.3
+name: Input and Data Sanitization and Filtering
+description: >-
+  Apply comprehensive input validation and sanitization to all data flowing
+  through MCP messages, including tool parameters, resource URIs, and prompt
+  content. Implement allowlists, schema validation, and context-aware
+  filtering to prevent injection attacks.
+elementType: control

--- a/package/oasisopen/cosai/mcp_security/elements/c_3_2_4.yml
+++ b/package/oasisopen/cosai/mcp_security/elements/c_3_2_4.yml
@@ -1,0 +1,9 @@
+id: c55cb584-df61-4c28-9458-12e1d7f806cd
+externalId: C-3.2.4
+name: Cryptographic Integrity and Remote Attestation
+description: >-
+  Use cryptographic signatures and remote attestation to verify the integrity
+  of MCP tool definitions, server responses, and resource content. Implement
+  hash-based verification, signed manifests, and attestation protocols to
+  detect tampering.
+elementType: control

--- a/package/oasisopen/cosai/mcp_security/elements/c_3_2_5.yml
+++ b/package/oasisopen/cosai/mcp_security/elements/c_3_2_5.yml
@@ -1,0 +1,9 @@
+id: 9f295d1a-b849-4069-8542-7db5dbbfa9b8
+externalId: C-3.2.5
+name: Sandboxing and Isolation
+description: >-
+  Deploy MCP servers and tool executions within sandboxed environments with
+  strict resource isolation. Use containerization, process isolation, and
+  network segmentation to contain potential compromises and prevent lateral
+  movement between MCP components.
+elementType: control

--- a/package/oasisopen/cosai/mcp_security/elements/c_3_2_6.yml
+++ b/package/oasisopen/cosai/mcp_security/elements/c_3_2_6.yml
@@ -1,0 +1,9 @@
+id: 6cb05192-c713-4545-a523-11c966c5eb95
+externalId: C-3.2.6
+name: Cryptographic Verification of Resources
+description: >-
+  Implement cryptographic verification for MCP resources including server
+  packages, tool definitions, and data sources. Use code signing, package
+  integrity checks, and trusted registries to ensure resource authenticity
+  and prevent supply chain attacks.
+elementType: control

--- a/package/oasisopen/cosai/mcp_security/elements/c_3_2_7.yml
+++ b/package/oasisopen/cosai/mcp_security/elements/c_3_2_7.yml
@@ -1,0 +1,9 @@
+id: 47b501ab-ddf7-43b0-aad8-9f7fc18ec2f4
+externalId: C-3.2.7
+name: Transport Layer Security
+description: >-
+  Enforce TLS 1.3 or equivalent encryption for all MCP network communications.
+  Implement certificate validation, certificate pinning where appropriate,
+  and secure configuration of both HTTP/SSE and stdio transport mechanisms
+  to protect data in transit.
+elementType: control

--- a/package/oasisopen/cosai/mcp_security/elements/c_3_2_8.yml
+++ b/package/oasisopen/cosai/mcp_security/elements/c_3_2_8.yml
@@ -1,0 +1,9 @@
+id: f41ea0c3-9591-4668-b15a-ee0aad9d8b72
+externalId: C-3.2.8
+name: Secure Tool and UX Design
+description: >-
+  Design MCP tool interfaces and user experiences that clearly communicate
+  security implications to users. Implement clear permission prompts,
+  action previews, and risk indicators to enable informed consent for
+  tool invocations with security-sensitive operations.
+elementType: control

--- a/package/oasisopen/cosai/mcp_security/elements/c_3_2_9.yml
+++ b/package/oasisopen/cosai/mcp_security/elements/c_3_2_9.yml
@@ -1,0 +1,9 @@
+id: 135028c6-4429-4ceb-9e1c-51488d6baf05
+externalId: C-3.2.9
+name: Human-in-the-Loop
+description: >-
+  Require explicit human approval for high-risk MCP tool invocations including
+  data modifications, external communications, and privileged operations.
+  Implement approval workflows, break-glass procedures, and escalation
+  mechanisms to maintain human oversight of agentic actions.
+elementType: control

--- a/package/oasisopen/cosai/mcp_security/elements/contextualized_threats.yml
+++ b/package/oasisopen/cosai/mcp_security/elements/contextualized_threats.yml
@@ -1,0 +1,8 @@
+id: b5181348-6bdd-4b0b-9a94-61f1366fa625
+externalId: MCP-Contextualized-Threats
+name: MCP-Contextualized Threats
+description: >-
+  Known security threats that take on new significance or manifest differently
+  in the MCP context, including data protection, integrity verification,
+  transport security, network isolation, and trust boundary design failures.
+elementType: threat_category

--- a/package/oasisopen/cosai/mcp_security/elements/conventional_threats.yml
+++ b/package/oasisopen/cosai/mcp_security/elements/conventional_threats.yml
@@ -1,0 +1,8 @@
+id: a8bad5ed-a037-418f-acb0-ba7d454e86a3
+externalId: Conventional-Security-Threats
+name: Conventional Security Threats
+description: >-
+  Standard security threats that apply to MCP implementations as they would to
+  any networked software system, including resource management, supply chain
+  security, and logging and monitoring adequacy.
+elementType: threat_category

--- a/package/oasisopen/cosai/mcp_security/elements/mcp_specific_threats.yml
+++ b/package/oasisopen/cosai/mcp_security/elements/mcp_specific_threats.yml
@@ -1,0 +1,8 @@
+id: f4ad2465-e058-4100-96d0-bd42f6db08b3
+externalId: MCP-Specific-Threats
+name: MCP-Specific Threats
+description: >-
+  Threats that are unique to MCP's architecture and protocol design, including
+  authentication, access control, input validation, and instruction boundary
+  failures specific to the MCP protocol.
+elementType: threat_category

--- a/package/oasisopen/cosai/mcp_security/elements/mcp_t1.yml
+++ b/package/oasisopen/cosai/mcp_security/elements/mcp_t1.yml
@@ -1,0 +1,10 @@
+id: 245400ea-413f-4020-b57e-82cd0b995cd6
+externalId: MCP-T1
+name: Improper Authentication and Identity Management
+description: >-
+  MCP lacks a built-in authentication framework, leaving identity verification
+  to individual implementations. This creates risks of unauthenticated access,
+  identity spoofing, and credential theft across MCP clients, servers, and
+  transport layers.
+elementType: threat_category
+parent: mcp_specific_threats

--- a/package/oasisopen/cosai/mcp_security/elements/mcp_t10.yml
+++ b/package/oasisopen/cosai/mcp_security/elements/mcp_t10.yml
@@ -1,0 +1,10 @@
+id: 83b2d357-9cad-4f4c-a596-255b7f1d3a0c
+externalId: MCP-T10
+name: Resource Management/Rate Limiting Absence
+description: >-
+  MCP does not define resource management or rate limiting mechanisms,
+  enabling denial-of-service attacks through excessive tool invocations,
+  resource exhaustion, recursive tool calls, and unbounded context
+  consumption in MCP-connected AI systems.
+elementType: threat_category
+parent: conventional_threats

--- a/package/oasisopen/cosai/mcp_security/elements/mcp_t11.yml
+++ b/package/oasisopen/cosai/mcp_security/elements/mcp_t11.yml
@@ -1,0 +1,10 @@
+id: 2b140b1f-e931-4d02-a59c-362399565b16
+externalId: MCP-T11
+name: Supply Chain and Lifecycle Security Failures
+description: >-
+  Risks from the MCP server ecosystem including malicious or compromised MCP
+  servers, typosquatting in server registries, lack of server provenance
+  verification, insecure update mechanisms, and dependency vulnerabilities
+  in MCP server implementations.
+elementType: threat_category
+parent: conventional_threats

--- a/package/oasisopen/cosai/mcp_security/elements/mcp_t12.yml
+++ b/package/oasisopen/cosai/mcp_security/elements/mcp_t12.yml
@@ -1,0 +1,10 @@
+id: e1035e3f-c509-41f5-b5ce-32f1db2225eb
+externalId: MCP-T12
+name: Insufficient Logging, Monitoring, and Auditability
+description: >-
+  Inadequate logging and monitoring capabilities in MCP implementations,
+  making it difficult to detect security incidents, trace tool invocations,
+  audit data access patterns, and maintain accountability for actions taken
+  through MCP-connected AI systems.
+elementType: threat_category
+parent: conventional_threats

--- a/package/oasisopen/cosai/mcp_security/elements/mcp_t2.yml
+++ b/package/oasisopen/cosai/mcp_security/elements/mcp_t2.yml
@@ -1,0 +1,10 @@
+id: a9c951ed-babd-433b-8c6c-7987055f47ea
+externalId: MCP-T2
+name: Missing or Improper Access Control
+description: >-
+  MCP does not define access control mechanisms, leaving authorization decisions
+  to implementations. This can lead to excessive permissions, privilege escalation,
+  unauthorized resource access, and failure to enforce least-privilege principles
+  across MCP tool invocations.
+elementType: threat_category
+parent: mcp_specific_threats

--- a/package/oasisopen/cosai/mcp_security/elements/mcp_t3.yml
+++ b/package/oasisopen/cosai/mcp_security/elements/mcp_t3.yml
@@ -1,0 +1,10 @@
+id: 6932f3b8-36a3-4408-b8ee-2ad727b243f6
+externalId: MCP-T3
+name: Input Validation/Sanitization Failures
+description: >-
+  Insufficient validation and sanitization of inputs flowing through MCP tool
+  calls, prompts, and resource URIs, enabling injection attacks including
+  command injection, path traversal, SQL injection, and cross-site scripting
+  through MCP message payloads.
+elementType: threat_category
+parent: mcp_specific_threats

--- a/package/oasisopen/cosai/mcp_security/elements/mcp_t4.yml
+++ b/package/oasisopen/cosai/mcp_security/elements/mcp_t4.yml
@@ -1,0 +1,10 @@
+id: 7c4a2118-b4c9-4780-a7d3-c5e55af85d80
+externalId: MCP-T4
+name: Input/Instruction Boundary Distinction Failure
+description: >-
+  MCP does not enforce a distinction between trusted instructions and untrusted
+  data, creating risks of indirect prompt injection where attacker-controlled
+  data in MCP tool responses or resources is interpreted as instructions by
+  the LLM, leading to unauthorized actions.
+elementType: threat_category
+parent: mcp_specific_threats

--- a/package/oasisopen/cosai/mcp_security/elements/mcp_t5.yml
+++ b/package/oasisopen/cosai/mcp_security/elements/mcp_t5.yml
@@ -1,0 +1,10 @@
+id: f81a4d49-1adf-445a-8e13-0ebb2b18a37c
+externalId: MCP-T5
+name: Inadequate Data Protection and Confidentiality Controls
+description: >-
+  MCP does not define data classification or confidentiality mechanisms,
+  risking exposure of sensitive data through tool descriptions, resource
+  content, conversation context, or cross-server data leakage when multiple
+  MCP servers share a conversation context.
+elementType: threat_category
+parent: contextualized_threats

--- a/package/oasisopen/cosai/mcp_security/elements/mcp_t6.yml
+++ b/package/oasisopen/cosai/mcp_security/elements/mcp_t6.yml
@@ -1,0 +1,10 @@
+id: 419b2671-d695-4c5b-87ed-efdf9f02efa1
+externalId: MCP-T6
+name: Missing Integrity/Verification Controls
+description: >-
+  MCP lacks built-in integrity verification mechanisms for tool definitions,
+  resource content, and server responses, enabling tool definition tampering,
+  response manipulation, and man-in-the-middle attacks that can alter the
+  behavior of MCP-connected AI systems.
+elementType: threat_category
+parent: contextualized_threats

--- a/package/oasisopen/cosai/mcp_security/elements/mcp_t7.yml
+++ b/package/oasisopen/cosai/mcp_security/elements/mcp_t7.yml
@@ -1,0 +1,10 @@
+id: 85c3a468-76be-4954-ad7f-d88db4ad3716
+externalId: MCP-T7
+name: Session and Transport Security Failures
+description: >-
+  Vulnerabilities in MCP session management and transport layer security,
+  including session hijacking, token theft, replay attacks, and inadequate
+  encryption of MCP communications across both stdio and HTTP/SSE transport
+  mechanisms.
+elementType: threat_category
+parent: contextualized_threats

--- a/package/oasisopen/cosai/mcp_security/elements/mcp_t8.yml
+++ b/package/oasisopen/cosai/mcp_security/elements/mcp_t8.yml
@@ -1,0 +1,10 @@
+id: 7ad89a00-dacd-440b-9b22-bea827f87f1f
+externalId: MCP-T8
+name: Network Binding/Isolation Failures
+description: >-
+  MCP servers binding to network interfaces without proper isolation controls,
+  enabling unauthorized access from other processes or network hosts. This is
+  particularly critical for local MCP servers using SSE transport that may
+  inadvertently expose services beyond localhost.
+elementType: threat_category
+parent: contextualized_threats

--- a/package/oasisopen/cosai/mcp_security/elements/mcp_t9.yml
+++ b/package/oasisopen/cosai/mcp_security/elements/mcp_t9.yml
@@ -1,0 +1,10 @@
+id: 6d708ccf-51ce-4262-aed6-4b201cdb1a02
+externalId: MCP-T9
+name: Trust Boundary and Privilege Design Failures
+description: >-
+  Inadequate trust boundary enforcement in MCP deployments, where clients,
+  servers, and upstream services operate with excessive trust. This includes
+  confused deputy attacks, privilege escalation through tool chaining, and
+  failure to maintain proper isolation between MCP components.
+elementType: threat_category
+parent: contextualized_threats

--- a/package/oasisopen/cosai/mcp_security/index.yml
+++ b/package/oasisopen/cosai/mcp_security/index.yml
@@ -1,0 +1,27 @@
+id: 61cac656-3ed6-4b7e-add4-1b4893f8d09f
+name: CoSAI MCP Security
+externalId: CoSAI-MCP-Security
+description: >-
+  The CoSAI MCP Security framework provides a systematic threat analysis and
+  security control mapping for the Model Context Protocol (MCP). It identifies
+  12 threat categories across MCP-specific, contextualized, and conventional
+  security domains, along with 11 security controls for mitigating risks in
+  agentic AI systems that use MCP for tool integration.
+code: oasisopen_cosai_mcp_security
+status: approved
+url: https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/blob/main/model-context-protocol-security.md
+version: v1
+external: true
+internal: false
+elementTypes:
+  - id: 5ab45d54-3fe5-4e68-ab12-d9b99ceaf042
+    code: threat_category
+    name: Threat Category
+    description: MCP security threat category identifying specific attack vectors and vulnerabilities
+  - id: b7467c4e-ece2-41b8-b2d9-871c29e0c7dd
+    code: control
+    name: Control
+    description: Security control or mitigation measure for MCP threat categories
+mappingTypes:
+  - threat_category
+  - control

--- a/package/oasisopen/cosai/mcp_security/package.json
+++ b/package/oasisopen/cosai/mcp_security/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/framework-oasisopen-cosai-mcp_security",
+  "version": "0.0.0",
+  "description": "CoSAI MCP Security - Threat categories and security controls for the Model Context Protocol",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/framework.git",
+    "directory": "package/oasisopen/cosai/mcp_security/"
+  },
+  "scripts": {
+    "correct:deps": "tsx ../../../../scripts/correctDeps.ts",
+    "validate": "tsx ../../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "baselines/**",
+    "elements/**",
+    "mappings/**"
+  ],
+  "zerobias": {
+    "package": "oasisopen.cosai.mcp_security.framework",
+    "import-artifact": "framework",
+    "dataloader-version": "1.0.0"
+  },
+  "dependencies": {
+    "@zerobias-org/suite-oasisopen-cosai": "latest"
+  }
+}


### PR DESCRIPTION
## Summary
- Add CoSAI MCP Security framework with 26 elements:
  - 3 threat classification groups (MCP-Specific, Contextualized, Conventional)
  - 12 threat categories (MCP-T1 through MCP-T12)
  - 11 security controls (C-3.2.1 through C-3.2.11)
- Based on the CoSAI/OASIS Open MCP Security publication
- Depends on `@zerobias-org/suite-oasisopen-cosai` (PR: zerobias-org/suite#30)

## Test plan
- [x] Framework validation passes (`npm run validate`)
- [x] Verify suite dependency resolves after suite is published

🤖 Generated with [Claude Code](https://claude.com/claude-code)