### PR TITLE
feat: migrate 29 framework packages to gradle pipeline (batch 1: aiuc → complianceforge/scf)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,15 +56,25 @@ extra["contentValidator"] = { proj: org.gradle.api.Project ->
     require(projectDir.resolve(".npmrc").isFile)       { "$tag .npmrc missing in ${projectDir.path}" }
 
     // ── 1. Filesystem ↔ npm ↔ zerobias-block triangulation ──
+    //
+    // Dots-in-version carve-out: a handful of frameworks use dotted
+    // semver-style version directories (e.g. complianceforge/scf/2025.2.1).
+    // npm names allow dots and keep them literal. But zerobias.package is
+    // a dot-separated path the dataloader uses as a hierarchical key —
+    // literal dots in a version segment would parse as extra segments and
+    // break the format. So zerobias.package replaces those dots with
+    // underscores in the version segment only (e.g. 2025_2_1). Same kind
+    // of normalization suite uses for its nist/800-53 hyphens.
     val version = projectDir.name
     val frameworkCode = projectDir.parentFile.name
     val authority = projectDir.parentFile.parentFile.name
+    val packageVersion = version.replace(".", "_")
 
     val pkgDoc = SchemaPrimitives.parseJson(projectDir.resolve("package.json"))
     SchemaPrimitives.requirePackageIdentity(
         pkgDoc,
         expectedNpmName = "@zerobias-org/framework-$authority-$frameworkCode-$version",
-        expectedZerobiasPackage = "$authority.$frameworkCode.$version.framework",
+        expectedZerobiasPackage = "$authority.$frameworkCode.$packageVersion.framework",
         field = "$tag package.json",
     )
     require(SchemaPrimitives.getPath(pkgDoc, "zerobias.import-artifact") == "framework" ||

--- a/package/aiuc/aiuc_1/v1/build.gradle.kts
+++ b/package/aiuc/aiuc_1/v1/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/aiuc/aiuc_1/v1/gate-stamp.json
+++ b/package/aiuc/aiuc_1/v1/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-all-remaining",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/aiuc/aiuc_1/v1/package.json
+++ b/package/aiuc/aiuc_1/v1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-aiuc-aiuc_1-v1",
-  "version": "0.0.4",
+  "version": "2.0.0",
   "description": "AIUC-1 AI Agent Standard - The world's first AI agent standard for enterprise compliance",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/au/ism/v1/build.gradle.kts
+++ b/package/au/ism/v1/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/au/ism/v1/gate-stamp.json
+++ b/package/au/ism/v1/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-all-remaining",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/au/ism/v1/package.json
+++ b/package/au/ism/v1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-au-ism-v1",
-  "version": "1.1.3",
+  "version": "2.0.0",
   "description": "Australian Government Information Security Manual (ISM)",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/ca/osfi/v1/build.gradle.kts
+++ b/package/ca/osfi/v1/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/ca/osfi/v1/gate-stamp.json
+++ b/package/ca/osfi/v1/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-all-remaining",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/ca/osfi/v1/package.json
+++ b/package/ca/osfi/v1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-ca-osfi-v1",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "B-13",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/ca/pci/v10_171/build.gradle.kts
+++ b/package/ca/pci/v10_171/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/ca/pci/v10_171/gate-stamp.json
+++ b/package/ca/pci/v10_171/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-all-remaining",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/ca/pci/v10_171/package.json
+++ b/package/ca/pci/v10_171/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-ca-pci-v10_171",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "Protecting controlled information in non-Government of Canada systems and organizations (ITSP.10.171)",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/cis/csc/v8_1/build.gradle.kts
+++ b/package/cis/csc/v8_1/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/cis/csc/v8_1/gate-stamp.json
+++ b/package/cis/csc/v8_1/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-all-remaining",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/cis/csc/v8_1/package.json
+++ b/package/cis/csc/v8_1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-cis-csc-v8_1",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "Critical Security Controls (CSC)",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/cisa/ssdaf/v1/build.gradle.kts
+++ b/package/cisa/ssdaf/v1/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/cisa/ssdaf/v1/gate-stamp.json
+++ b/package/cisa/ssdaf/v1/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-all-remaining",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/cisa/ssdaf/v1/package.json
+++ b/package/cisa/ssdaf/v1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-cisa-ssdaf-v1",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "CISA Secure Software Development Attestation Form (SSDAF)",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/cisa/tic/v3/build.gradle.kts
+++ b/package/cisa/tic/v3/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/cisa/tic/v3/gate-stamp.json
+++ b/package/cisa/tic/v3/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-all-remaining",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/cisa/tic/v3/package.json
+++ b/package/cisa/tic/v3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-cisa-tic-v3",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "CISA Trusted Internet Connection (TIC) 3.0",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/cn/csl/v1/build.gradle.kts
+++ b/package/cn/csl/v1/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/cn/csl/v1/gate-stamp.json
+++ b/package/cn/csl/v1/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-all-remaining",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/cn/csl/v1/package.json
+++ b/package/cn/csl/v1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-cn-csl-v1",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "China Cybersecurity Law of the People's Republic of China (China Cybersecurity Law)",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/cncf/sscp/v1/build.gradle.kts
+++ b/package/cncf/sscp/v1/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/cncf/sscp/v1/gate-stamp.json
+++ b/package/cncf/sscp/v1/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-all-remaining",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/cncf/sscp/v1/package.json
+++ b/package/cncf/sscp/v1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-cncf-sscp-v1",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "CNCF SSCP v1 Framework",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/complianceforge/scf/2025.2.1/build.gradle.kts
+++ b/package/complianceforge/scf/2025.2.1/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/complianceforge/scf/2025.2.1/gate-stamp.json
+++ b/package/complianceforge/scf/2025.2.1/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-all-remaining",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/complianceforge/scf/2025.2.1/package.json
+++ b/package/complianceforge/scf/2025.2.1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-complianceforge-scf-2025.2.1",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "ComplianceForge SCF 2025.2.1 Controls",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/complianceforge/scf/2025.2.2/build.gradle.kts
+++ b/package/complianceforge/scf/2025.2.2/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/complianceforge/scf/2025.2.2/gate-stamp.json
+++ b/package/complianceforge/scf/2025.2.2/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-all-remaining",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/complianceforge/scf/2025.2.2/package.json
+++ b/package/complianceforge/scf/2025.2.2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-complianceforge-scf-2025.2.2",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "ComplianceForge SCF 2025.2.2 Controls",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/complianceforge/scf/2025.3.1/build.gradle.kts
+++ b/package/complianceforge/scf/2025.3.1/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/complianceforge/scf/2025.3.1/gate-stamp.json
+++ b/package/complianceforge/scf/2025.3.1/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-all-remaining",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/complianceforge/scf/2025.3.1/package.json
+++ b/package/complianceforge/scf/2025.3.1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-complianceforge-scf-2025.3.1",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "ComplianceForge SCF 2025.3.1 Controls",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/complianceforge/scf/2025.4/build.gradle.kts
+++ b/package/complianceforge/scf/2025.4/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/complianceforge/scf/2025.4/gate-stamp.json
+++ b/package/complianceforge/scf/2025.4/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-all-remaining",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/complianceforge/scf/2025.4/package.json
+++ b/package/complianceforge/scf/2025.4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-complianceforge-scf-2025.4",
-  "version": "1.0.5",
+  "version": "2.0.0",
   "description": "ComplianceForge SCF 2025.4 Controls",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/csa/aicm/v1/build.gradle.kts
+++ b/package/csa/aicm/v1/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/csa/aicm/v1/gate-stamp.json
+++ b/package/csa/aicm/v1/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-all-remaining",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/csa/aicm/v1/package.json
+++ b/package/csa/aicm/v1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-csa-aicm-v1",
-  "version": "0.0.4",
+  "version": "2.0.0",
   "description": "CSA AI Controls Matrix v1 - A vendor-agnostic framework for cloud-based AI systems",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/dod/ztra/v2/build.gradle.kts
+++ b/package/dod/ztra/v2/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/dod/ztra/v2/gate-stamp.json
+++ b/package/dod/ztra/v2/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-all-remaining",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/dod/ztra/v2/package.json
+++ b/package/dod/ztra/v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-dod-ztra-v2",
-  "version": "1.3.3",
+  "version": "2.0.0",
   "description": "DOD Zero Trust Reference Architecture (ZTRA)",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/es/boe/v2022/build.gradle.kts
+++ b/package/es/boe/v2022/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/es/boe/v2022/gate-stamp.json
+++ b/package/es/boe/v2022/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-all-remaining",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/es/boe/v2022/package.json
+++ b/package/es/boe/v2022/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-es-boe-v2022",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "BOE-A-2022-7191",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/es/royaldecree/2022/build.gradle.kts
+++ b/package/es/royaldecree/2022/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/es/royaldecree/2022/gate-stamp.json
+++ b/package/es/royaldecree/2022/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-all-remaining",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/es/royaldecree/2022/package.json
+++ b/package/es/royaldecree/2022/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-es-royaldecree-2022",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "Spain Royal Decree 311/2022",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/eu/ai/v2024/build.gradle.kts
+++ b/package/eu/ai/v2024/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/eu/ai/v2024/gate-stamp.json
+++ b/package/eu/ai/v2024/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-all-remaining",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/eu/ai/v2024/package.json
+++ b/package/eu/ai/v2024/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-eu-ai-v2024",
-  "version": "1.1.6",
+  "version": "2.0.0",
   "description": "EU Artificial Intelligence (AI)I Act (Regulation (EU) 2024/1689)",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/eu/cra/v1/build.gradle.kts
+++ b/package/eu/cra/v1/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/eu/cra/v1/gate-stamp.json
+++ b/package/eu/cra/v1/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-all-remaining",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/eu/cra/v1/package.json
+++ b/package/eu/cra/v1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-eu-cra-v1",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "EU Cyber Resilience Act",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/eu/cra_annex/v1/build.gradle.kts
+++ b/package/eu/cra_annex/v1/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/eu/cra_annex/v1/gate-stamp.json
+++ b/package/eu/cra_annex/v1/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-all-remaining",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/eu/cra_annex/v1/package.json
+++ b/package/eu/cra_annex/v1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-eu-cra_annex-v1",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "EU Cyber Resilience Act - Annexes",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/eu/dora/2023/build.gradle.kts
+++ b/package/eu/dora/2023/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/eu/dora/2023/gate-stamp.json
+++ b/package/eu/dora/2023/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-all-remaining",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/eu/dora/2023/package.json
+++ b/package/eu/dora/2023/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-eu-dora-2023",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "EU Digital Operational Resilience Act (DORA)",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/eu/enisa/annex/build.gradle.kts
+++ b/package/eu/enisa/annex/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/eu/enisa/annex/gate-stamp.json
+++ b/package/eu/enisa/annex/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-all-remaining",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/eu/enisa/annex/package.json
+++ b/package/eu/enisa/annex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-eu-enisa-annex",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "ENISA NIS2 Annex",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/eu/enisa/v1/build.gradle.kts
+++ b/package/eu/enisa/v1/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/eu/enisa/v1/gate-stamp.json
+++ b/package/eu/enisa/v1/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-all-remaining",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/eu/enisa/v1/package.json
+++ b/package/eu/enisa/v1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-eu-enisa-v1",
-  "version": "1.1.3",
+  "version": "2.0.0",
   "description": "ENISA NIS2 v1",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/eu/gdpr/v1/build.gradle.kts
+++ b/package/eu/gdpr/v1/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/eu/gdpr/v1/gate-stamp.json
+++ b/package/eu/gdpr/v1/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-all-remaining",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/eu/gdpr/v1/package.json
+++ b/package/eu/gdpr/v1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-eu-gdpr-v1",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "General Data Protection Regulation (GDPR)",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/gb/mds/v2024/build.gradle.kts
+++ b/package/gb/mds/v2024/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/gb/mds/v2024/gate-stamp.json
+++ b/package/gb/mds/v2024/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-all-remaining",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/gb/mds/v2024/package.json
+++ b/package/gb/mds/v2024/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-gb-mds-v2024",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "Ministry of Defence Standard 05-138 (14 May 2024)",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/iec/60601/2021/build.gradle.kts
+++ b/package/iec/60601/2021/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/iec/60601/2021/gate-stamp.json
+++ b/package/iec/60601/2021/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-all-remaining",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/iec/60601/2021/package.json
+++ b/package/iec/60601/2021/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-iec-60601-2021",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "IEC TR 60601-4-5:2021",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/in/dpdpa/2023/build.gradle.kts
+++ b/package/in/dpdpa/2023/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/in/dpdpa/2023/gate-stamp.json
+++ b/package/in/dpdpa/2023/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-all-remaining",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/in/dpdpa/2023/package.json
+++ b/package/in/dpdpa/2023/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-in-dpdpa-2023",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "Digital Personal Data Protection Act, 2023",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/iso/27001/2022/build.gradle.kts
+++ b/package/iso/27001/2022/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/iso/27001/2022/gate-stamp.json
+++ b/package/iso/27001/2022/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-all-remaining",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/iso/27001/2022/package.json
+++ b/package/iso/27001/2022/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-iso-27001-2022",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "27001 - Information Security Management Systems (ISMS) - Requirements",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/iso/27002/2022/build.gradle.kts
+++ b/package/iso/27002/2022/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/iso/27002/2022/gate-stamp.json
+++ b/package/iso/27002/2022/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-all-remaining",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/iso/27002/2022/package.json
+++ b/package/iso/27002/2022/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-iso-27002-2022",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "27002 - Information security, cybersecurity and privacy protection - Information security controls",
   "author": "team@zerobias.com",
   "license": "ISC",


### PR DESCRIPTION
## Summary

First per-package batch on the gradle pipeline. **29 framework packages + 1 validator change = 30 commits.**

| Section | Count | Range |
|---|---|---|
| Validator fix | 1 commit | `chore(validator): normalize dots → underscores in version segment of zerobias.package` |
| Alphabetical first-25 batch | 25 commits | `aiuc/aiuc_1/v1` → `iso/27002/2022` |
| complianceforge/scf umbrella | 4 commits | All 4 dotted-version packages — unblocked by the validator fix |

All bumped to `2.0.0` per repo convention. Local `:gate` passed for all 29 in parallel (~13s). Includes the `eu/enisa` umbrella whole (both `annex` and `v1`).

## Validator fix detail

A handful of framework packages use dotted-semver-style version directories (e.g. `complianceforge/scf/2025.2.1`). npm names allow dots and keep them literal, but `zerobias.package` is a dot-separated path the dataloader uses as a hierarchical key — literal dots in a version segment would parse as extra segments and break the format. So `zerobias.package` replaces those dots with underscores in the version segment only (e.g. `complianceforge.scf.2025_2_1.framework`). Same kind of normalization that suite uses for its `nist/800-53` hyphen-strip → `nist.80053`.

The existing on-disk values for the 4 complianceforge/scf packages already use this normalized form (they've been published since 1.0.3 / 1.0.4) — the validator just needed to compute the expected `zerobias.package` the same way. One-line change: `val packageVersion = version.replace(".", "_")` in `build.gradle.kts`.

## Skipped from this batch

- **`iso/270001/2022`** — separate data inconsistency (dirname says `iso/270001/2022` but npm name is `framework-iso-27001-2022a` — missing zero AND extra `a`). Needs investigation to decide which side is canonical. Tracking as a follow-up.

## Progress after merge

- 32 of 75 packages migrated (3 from PR #206 + 29 here)
- 42 clean packages + 1 anomaly remain
- Next batch of ~25 can proceed once this lands

## Test plan

- [x] Local `:gate` green on all 29 in parallel (~13s)
- [ ] CI `detect` lists exactly these 29 packages
- [ ] CI `publish` matrix succeeds per-package
- [ ] `testIntegrationDataloader` passes per-package against ephemeral Neon branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)