### PR TITLE
feat: migrate 25 framework packages to gradle pipeline (batch 2: iso/42001/2023 → us_ca/cpra/2022)

### DIFF
--- a/package/iso/42001/2023/build.gradle.kts
+++ b/package/iso/42001/2023/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/iso/42001/2023/gate-stamp.json
+++ b/package/iso/42001/2023/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/iso/42001/2023/package.json
+++ b/package/iso/42001/2023/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-iso-42001-2023",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "ISO/IEC 42001:2023 - Information technology - Artificial intelligence - Management system",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/naic/mdl/v1/build.gradle.kts
+++ b/package/naic/mdl/v1/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/naic/mdl/v1/gate-stamp.json
+++ b/package/naic/mdl/v1/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/naic/mdl/v1/package.json
+++ b/package/naic/mdl/v1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-naic-mdl-v1",
-  "version": "1.1.3",
+  "version": "2.0.0",
   "description": "Insurance Data Security Model Law (MDL-668)",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/nist/800-171/rev2/build.gradle.kts
+++ b/package/nist/800-171/rev2/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/nist/800-171/rev2/gate-stamp.json
+++ b/package/nist/800-171/rev2/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/nist/800-171/rev2/package.json
+++ b/package/nist/800-171/rev2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-nist-800-171-rev2",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "SP 800-171 - Protecting CUI in Nonfederal Systems and Organizations",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/nist/800-171/rev3/build.gradle.kts
+++ b/package/nist/800-171/rev3/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/nist/800-171/rev3/gate-stamp.json
+++ b/package/nist/800-171/rev3/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/nist/800-171/rev3/package.json
+++ b/package/nist/800-171/rev3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-nist-800-171-rev3",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "NIST SP 800-171 R3",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/nist/800-53/v5/build.gradle.kts
+++ b/package/nist/800-53/v5/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/nist/800-53/v5/gate-stamp.json
+++ b/package/nist/800-53/v5/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/nist/800-53/v5/package.json
+++ b/package/nist/800-53/v5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-nist-800-53-v5",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "NIST SP 800-53 R5 - Security and Privacy Controls for Information Systems and Organizations",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/nist/800_161/rev1/build.gradle.kts
+++ b/package/nist/800_161/rev1/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/nist/800_161/rev1/gate-stamp.json
+++ b/package/nist/800_161/rev1/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/nist/800_161/rev1/package.json
+++ b/package/nist/800_161/rev1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-nist-800_161-rev1",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "NIST SP 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/nist/800_171a/r3/build.gradle.kts
+++ b/package/nist/800_171a/r3/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/nist/800_171a/r3/gate-stamp.json
+++ b/package/nist/800_171a/r3/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/nist/800_171a/r3/package.json
+++ b/package/nist/800_171a/r3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-nist-800_171a-r3",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "NIST 800-171A R3",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/nist/800_171a/v1/build.gradle.kts
+++ b/package/nist/800_171a/v1/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/nist/800_171a/v1/gate-stamp.json
+++ b/package/nist/800_171a/v1/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/nist/800_171a/v1/package.json
+++ b/package/nist/800_171a/v1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-nist-800_171a-v1",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "SP 800-171A - Assessing Security Requirements for Controlled Unclassified Information",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/nist/800_218/v1_1/build.gradle.kts
+++ b/package/nist/800_218/v1_1/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/nist/800_218/v1_1/gate-stamp.json
+++ b/package/nist/800_218/v1_1/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/nist/800_218/v1_1/package.json
+++ b/package/nist/800_218/v1_1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-nist-800_218-v1_1",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "SP 800-218 - Secure Software Development Framework (SSDF) Version 1.1:",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/nist/ai_600/v1/build.gradle.kts
+++ b/package/nist/ai_600/v1/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/nist/ai_600/v1/gate-stamp.json
+++ b/package/nist/ai_600/v1/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/nist/ai_600/v1/package.json
+++ b/package/nist/ai_600/v1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-nist-ai_600-v1",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "NIST AI 600-1 (AI RMF Generative Artificial Intelligence Profile)",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/nist/csf/v2/build.gradle.kts
+++ b/package/nist/csf/v2/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/nist/csf/v2/gate-stamp.json
+++ b/package/nist/csf/v2/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/nist/csf/v2/package.json
+++ b/package/nist/csf/v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-nist-csf-v2",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "Cybersecurity Framework (CSF) 2.0",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/nist/label/2022/build.gradle.kts
+++ b/package/nist/label/2022/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/nist/label/2022/gate-stamp.json
+++ b/package/nist/label/2022/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/nist/label/2022/package.json
+++ b/package/nist/label/2022/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-nist-label-2022",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "NIST Label 2022 Framework",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/nist/rmf/v1/build.gradle.kts
+++ b/package/nist/rmf/v1/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/nist/rmf/v1/gate-stamp.json
+++ b/package/nist/rmf/v1/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/nist/rmf/v1/package.json
+++ b/package/nist/rmf/v1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-nist-rmf-v1",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "NIST Artificial Intelligence Risk Management Framework (AI RMF)",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/nz/hisf/suppliers/build.gradle.kts
+++ b/package/nz/hisf/suppliers/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/nz/hisf/suppliers/gate-stamp.json
+++ b/package/nz/hisf/suppliers/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/nz/hisf/suppliers/package.json
+++ b/package/nz/hisf/suppliers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-nz-hisf-suppliers",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "NZ Health Information Security Framework for Suppliers",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/nz/hisf/v1/build.gradle.kts
+++ b/package/nz/hisf/v1/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/nz/hisf/v1/gate-stamp.json
+++ b/package/nz/hisf/v1/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/nz/hisf/v1/package.json
+++ b/package/nz/hisf/v1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-nz-hisf-v1",
-  "version": "1.1.3",
+  "version": "2.0.0",
   "description": "NZ Health Information Security Framework for Suppliers",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/oasisopen/cosai/mcp_security/build.gradle.kts
+++ b/package/oasisopen/cosai/mcp_security/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/oasisopen/cosai/mcp_security/gate-stamp.json
+++ b/package/oasisopen/cosai/mcp_security/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/oasisopen/cosai/mcp_security/package.json
+++ b/package/oasisopen/cosai/mcp_security/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-oasisopen-cosai-mcp_security",
-  "version": "0.0.1",
+  "version": "2.0.0",
   "description": "CoSAI MCP Security - Threat categories and security controls for the Model Context Protocol",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/opencre/opencre/v1/build.gradle.kts
+++ b/package/opencre/opencre/v1/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/opencre/opencre/v1/gate-stamp.json
+++ b/package/opencre/opencre/v1/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/opencre/opencre/v1/package.json
+++ b/package/opencre/opencre/v1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-opencre-opencre-v1",
-  "version": "1.2.4",
+  "version": "2.0.0",
   "description": "OpenCRE framework",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/owasp/llmtop10/v2025/build.gradle.kts
+++ b/package/owasp/llmtop10/v2025/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/owasp/llmtop10/v2025/gate-stamp.json
+++ b/package/owasp/llmtop10/v2025/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/owasp/llmtop10/v2025/package.json
+++ b/package/owasp/llmtop10/v2025/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-owasp-llmtop10-v2025",
-  "version": "0.0.4",
+  "version": "2.0.0",
   "description": "OWASP Top 10 for Large Language Model Applications - Security vulnerabilities in LLM systems",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/pci_ssc/dss/v4_0_1/build.gradle.kts
+++ b/package/pci_ssc/dss/v4_0_1/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/pci_ssc/dss/v4_0_1/gate-stamp.json
+++ b/package/pci_ssc/dss/v4_0_1/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/pci_ssc/dss/v4_0_1/package.json
+++ b/package/pci_ssc/dss/v4_0_1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-pci_ssc-dss-v4_0_1",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "Payment Card Industry Data Security Standard (PCI DSS)",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/sa/pdpl/v1/build.gradle.kts
+++ b/package/sa/pdpl/v1/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/sa/pdpl/v1/gate-stamp.json
+++ b/package/sa/pdpl/v1/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/sa/pdpl/v1/package.json
+++ b/package/sa/pdpl/v1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-sa-pdpl-v1",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "Personal Data Protection Law (PDPL)",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/sa/sai/v2024/build.gradle.kts
+++ b/package/sa/sai/v2024/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/sa/sai/v2024/gate-stamp.json
+++ b/package/sa/sai/v2024/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/sa/sai/v2024/package.json
+++ b/package/sa/sai/v2024/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-sa-sai-v2024",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "Saudi Arabia IoT CGIoT-1:2024",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/sparta/counter/v1/build.gradle.kts
+++ b/package/sparta/counter/v1/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/sparta/counter/v1/gate-stamp.json
+++ b/package/sparta/counter/v1/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/sparta/counter/v1/package.json
+++ b/package/sparta/counter/v1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-sparta-counter-v1",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "Space Attack Research & Tactic Analysis (SPARTA) Countermeasures",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/tisax/isa/v6_0_3/build.gradle.kts
+++ b/package/tisax/isa/v6_0_3/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/tisax/isa/v6_0_3/gate-stamp.json
+++ b/package/tisax/isa/v6_0_3/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/tisax/isa/v6_0_3/package.json
+++ b/package/tisax/isa/v6_0_3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-tisax-isa-v6_0_3",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "TISAX ISA",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/uae/niaf/v1/build.gradle.kts
+++ b/package/uae/niaf/v1/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/uae/niaf/v1/gate-stamp.json
+++ b/package/uae/niaf/v1/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/uae/niaf/v1/package.json
+++ b/package/uae/niaf/v1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-uae-niaf-v1",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "UAE National Information Assurance Framework (NIAF)",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/us_ca/cpra/2022/build.gradle.kts
+++ b/package/us_ca/cpra/2022/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/us_ca/cpra/2022/gate-stamp.json
+++ b/package/us_ca/cpra/2022/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/us_ca/cpra/2022/package.json
+++ b/package/us_ca/cpra/2022/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-us_ca-cpra-2022",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "Privacy Rights Act (CPRA) - November 2022 version",
   "author": "team@zerobias.com",
   "license": "ISC",


### PR DESCRIPTION
## Summary

Second per-package batch. **25 framework packages**, alphabetical `iso/42001/2023` → `us_ca/cpra/2022`. All bumped to `2.0.0`. Local `:gate` green in parallel (~11s, 461 tasks).

Umbrellas kept whole: `nist/800_171a/{r3,v1}`, `nist/800-171/{rev2,rev3}`, `nz/hisf/{suppliers,v1}`.

Notable inclusions: `nist/800-53/v5`, `nist/csf/v2`, `nist/rmf/v1`, `pci_ssc/dss/v4_0_1`, `opencre/opencre/v1`, `oasisopen/cosai/mcp_security`.

## Progress after merge

57 of 75 packages migrated. Remaining: 17 clean + 1 anomaly (`iso/270001/2022`).

## Test plan

- [x] Local `:gate` green on all 25 (parallel, ~11s)
- [ ] CI `detect` lists exactly these 25
- [ ] CI `publish` matrix succeeds per-package
- [ ] `testIntegrationDataloader` passes per-package

🤖 Generated with [Claude Code](https://claude.com/claude-code)