### PR TITLE
feat: migrate final 16 framework packages to gradle pipeline (batch 3: us_ny/dfs → us/nerc)

### DIFF
--- a/package/us/cisa/2022/build.gradle.kts
+++ b/package/us/cisa/2022/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/us/cisa/2022/gate-stamp.json
+++ b/package/us/cisa/2022/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-batch-3",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/us/cisa/2022/package.json
+++ b/package/us/cisa/2022/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-us-cisa-2022",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "CISA Cross-Sector Cybersecurity Performance Goals (CPG)",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/us/cjis/v5_9_3/build.gradle.kts
+++ b/package/us/cjis/v5_9_3/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/us/cjis/v5_9_3/gate-stamp.json
+++ b/package/us/cjis/v5_9_3/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-batch-3",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/us/cjis/v5_9_3/package.json
+++ b/package/us/cjis/v5_9_3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-us-cjis-v5_9_3",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "US DOJ / FBI - Criminal Justice Information Services (CJIS) Security Policy",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/us/cybersecurity_rule/v1/build.gradle.kts
+++ b/package/us/cybersecurity_rule/v1/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/us/cybersecurity_rule/v1/gate-stamp.json
+++ b/package/us/cybersecurity_rule/v1/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-batch-3",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/us/cybersecurity_rule/v1/package.json
+++ b/package/us/cybersecurity_rule/v1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-us-cybersecurity_rule-v1",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "Cybersecurity Final Rule (Cybersecurity Risk Management, Strategy, Governance, and Incident Disclosure) - 17 CFR Parts 229, 232, 239, 240, and 249",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/us/dpf/v1/build.gradle.kts
+++ b/package/us/dpf/v1/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/us/dpf/v1/gate-stamp.json
+++ b/package/us/dpf/v1/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-batch-3",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/us/dpf/v1/package.json
+++ b/package/us/dpf/v1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-us-dpf-v1",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "Data Privacy Framework (DPF)",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/us/fca/v1/build.gradle.kts
+++ b/package/us/fca/v1/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/us/fca/v1/gate-stamp.json
+++ b/package/us/fca/v1/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-batch-3",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/us/fca/v1/package.json
+++ b/package/us/fca/v1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-us-fca-v1",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "Farm Credit Administration (FCA) Cyber Risk Management",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/us/fda/v21/build.gradle.kts
+++ b/package/us/fda/v21/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/us/fda/v21/gate-stamp.json
+++ b/package/us/fda/v21/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-batch-3",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/us/fda/v21/package.json
+++ b/package/us/fda/v21/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-us-fda-v21",
-  "version": "1.1.3",
+  "version": "2.0.0",
   "description": "Food & Drug Administration (FDA)",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/us/glba/2023/build.gradle.kts
+++ b/package/us/glba/2023/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/us/glba/2023/gate-stamp.json
+++ b/package/us/glba/2023/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-batch-3",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/us/glba/2023/package.json
+++ b/package/us/glba/2023/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-us-glba-2023",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "Gramm Leach Bliley Act (GLBA) - CFR 314",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/us/hicp/v1/build.gradle.kts
+++ b/package/us/hicp/v1/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/us/hicp/v1/gate-stamp.json
+++ b/package/us/hicp/v1/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-batch-3",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/us/hicp/v1/package.json
+++ b/package/us/hicp/v1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-us-hicp-v1",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "Health Industry Cybersecurity Practices (HICP)",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/us/hipaa/v2/build.gradle.kts
+++ b/package/us/hipaa/v2/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/us/hipaa/v2/gate-stamp.json
+++ b/package/us/hipaa/v2/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-batch-3",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/us/hipaa/v2/package.json
+++ b/package/us/hipaa/v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-us-hipaa-v2",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "HIPAA Security Rule (includes mapping to NIST SP 800-66 R2)",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/us/hipaa/v2013/build.gradle.kts
+++ b/package/us/hipaa/v2013/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/us/hipaa/v2013/gate-stamp.json
+++ b/package/us/hipaa/v2013/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-batch-3",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/us/hipaa/v2013/package.json
+++ b/package/us/hipaa/v2013/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-us-hipaa-v2013",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "HIPAA Administrative Simplification (2013)",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/us/mars_e/v2/build.gradle.kts
+++ b/package/us/mars_e/v2/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/us/mars_e/v2/gate-stamp.json
+++ b/package/us/mars_e/v2/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-batch-3",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/us/mars_e/v2/package.json
+++ b/package/us/mars_e/v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-us-mars_e-v2",
-  "version": "1.1.3",
+  "version": "2.0.0",
   "description": "US Centers for Medicare & Medicaid Services MARS-E Document Suite, Version 2.0",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/us/nerc/2024/build.gradle.kts
+++ b/package/us/nerc/2024/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/us/nerc/2024/gate-stamp.json
+++ b/package/us/nerc/2024/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-batch-3",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/us/nerc/2024/package.json
+++ b/package/us/nerc/2024/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-us-nerc-2024",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "North American Electric Reliability Corporation Critical Infrastructure Protection (NERC CIP)",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/us_ny/dfs/2023/build.gradle.kts
+++ b/package/us_ny/dfs/2023/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/us_ny/dfs/2023/gate-stamp.json
+++ b/package/us_ny/dfs/2023/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-batch-3",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/us_ny/dfs/2023/package.json
+++ b/package/us_ny/dfs/2023/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-us_ny-dfs-2023",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "Cybersecurity Requirements for Financial Services Companies (DFS 23 NYCRR500) - 2023 Amendment 2",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/us_or/cpa/v1/build.gradle.kts
+++ b/package/us_or/cpa/v1/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/us_or/cpa/v1/gate-stamp.json
+++ b/package/us_or/cpa/v1/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-batch-3",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/us_or/cpa/v1/package.json
+++ b/package/us_or/cpa/v1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-us_or-cpa-v1",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "OR - Consumer Privacy Act (SB 619)",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/us_tn/ipa/v1/build.gradle.kts
+++ b/package/us_tn/ipa/v1/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/us_tn/ipa/v1/gate-stamp.json
+++ b/package/us_tn/ipa/v1/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-batch-3",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/us_tn/ipa/v1/package.json
+++ b/package/us_tn/ipa/v1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-us_tn-ipa-v1",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "Information Protection Act",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/us_tx/cdpa/v1/build.gradle.kts
+++ b/package/us_tx/cdpa/v1/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/us_tx/cdpa/v1/gate-stamp.json
+++ b/package/us_tx/cdpa/v1/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0-uat.0",
+  "branch": "chore/migrate-batch-3",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/us_tx/cdpa/v1/package.json
+++ b/package/us_tx/cdpa/v1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-us_tx-cdpa-v1",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "Texas Consumer Data Protection Act",
   "author": "team@zerobias.com",
   "license": "ISC",


### PR DESCRIPTION
## Summary

Third and final clean batch. **16 framework packages** — all the remaining `us*` jurisdiction frameworks. All bumped to `2.0.0`. Local `:gate` green in parallel (~7s, 299 tasks).

Umbrella kept whole: `us/hipaa/{v2,v2013}`.

## Progress after merge

**73 of 75 packages migrated.** The only remaining package is `iso/270001/2022` — a data inconsistency (dirname `iso/270001/2022` vs npm name `framework-iso-27001-2022a`) that needs a canonical-shape decision before migration.

The 2 `update` utility packages (`opencre/opencre/update`, `complianceforge/scf/update`) are intentionally never migrated — they're private content-fetcher tools, not framework artifacts.

## Test plan

- [x] Local `:gate` green on all 16 (parallel, ~7s)
- [ ] CI `detect` lists exactly these 16
- [ ] CI `publish` matrix succeeds per-package
- [ ] `testIntegrationDataloader` passes per-package

🤖 Generated with [Claude Code](https://claude.com/claude-code)