### PR TITLE
chore(framework): deprecate 8 old frameworks that belong in auditlogic

### DIFF
--- a/package/iec/60601/2021/gate-stamp.json
+++ b/package/iec/60601/2021/gate-stamp.json
@@ -1,6 +1,6 @@
 {
-  "version": "2.0.0-uat.0",
-  "branch": "chore/migrate-all-remaining",
+  "version": "2.0.1-uat.0",
+  "branch": "chore/deprecate-old-dupes",
   "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "tasks": {

--- a/package/iec/60601/2021/package.json
+++ b/package/iec/60601/2021/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-iec-60601-2021",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "IEC TR 60601-4-5:2021",
   "author": "team@zerobias.com",
   "license": "ISC",
@@ -25,7 +25,8 @@
   "zerobias": {
     "package": "iec.60601.2021.framework",
     "import-artifact": "framework",
-    "dataloader-version": "1.0.0"
+    "dataloader-version": "1.0.0",
+    "deprecated": true
   },
   "dependencies": {
     "@zerobias-org/suite-iec-60601": "latest"

--- a/package/iso/42001/2023/gate-stamp.json
+++ b/package/iso/42001/2023/gate-stamp.json
@@ -1,6 +1,6 @@
 {
-  "version": "2.0.0-uat.0",
-  "branch": "chore/migrate-batch-2",
+  "version": "2.0.1-uat.0",
+  "branch": "chore/deprecate-old-dupes",
   "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "tasks": {

--- a/package/iso/42001/2023/package.json
+++ b/package/iso/42001/2023/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-iso-42001-2023",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "ISO/IEC 42001:2023 - Information technology - Artificial intelligence - Management system",
   "author": "team@zerobias.com",
   "license": "ISC",
@@ -25,7 +25,8 @@
   "zerobias": {
     "package": "iso.42001.2023.framework",
     "import-artifact": "framework",
-    "dataloader-version": "1.0.0"
+    "dataloader-version": "1.0.0",
+    "deprecated": true
   },
   "dependencies": {
     "@zerobias-org/suite-iso-42001": "latest"

--- a/package/nist/800-171/rev2/gate-stamp.json
+++ b/package/nist/800-171/rev2/gate-stamp.json
@@ -1,6 +1,6 @@
 {
-  "version": "2.0.0-uat.0",
-  "branch": "chore/migrate-batch-2",
+  "version": "2.0.1-uat.0",
+  "branch": "chore/deprecate-old-dupes",
   "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "tasks": {

--- a/package/nist/800-171/rev2/package.json
+++ b/package/nist/800-171/rev2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-nist-800-171-rev2",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "SP 800-171 - Protecting CUI in Nonfederal Systems and Organizations",
   "author": "team@zerobias.com",
   "license": "ISC",
@@ -25,7 +25,8 @@
   "zerobias": {
     "package": "nist.800-171.rev2.framework",
     "import-artifact": "framework",
-    "dataloader-version": "1.0.0"
+    "dataloader-version": "1.0.0",
+    "deprecated": true
   },
   "dependencies": {
     "@zerobias-org/suite-nist-800-171": "latest"

--- a/package/nist/800-171/rev3/gate-stamp.json
+++ b/package/nist/800-171/rev3/gate-stamp.json
@@ -1,6 +1,6 @@
 {
-  "version": "2.0.0-uat.0",
-  "branch": "chore/migrate-batch-2",
+  "version": "2.0.1-uat.0",
+  "branch": "chore/deprecate-old-dupes",
   "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "tasks": {

--- a/package/nist/800-171/rev3/package.json
+++ b/package/nist/800-171/rev3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-nist-800-171-rev3",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "NIST SP 800-171 R3",
   "author": "team@zerobias.com",
   "license": "ISC",
@@ -25,7 +25,8 @@
   "zerobias": {
     "package": "nist.800-171.rev3.framework",
     "import-artifact": "framework",
-    "dataloader-version": "1.0.0"
+    "dataloader-version": "1.0.0",
+    "deprecated": true
   },
   "dependencies": {
     "@zerobias-org/suite-nist-800-171": "latest"

--- a/package/nist/800_218/v1_1/gate-stamp.json
+++ b/package/nist/800_218/v1_1/gate-stamp.json
@@ -1,6 +1,6 @@
 {
-  "version": "2.0.0-uat.0",
-  "branch": "chore/migrate-batch-2",
+  "version": "2.0.1-uat.0",
+  "branch": "chore/deprecate-old-dupes",
   "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "tasks": {

--- a/package/nist/800_218/v1_1/package.json
+++ b/package/nist/800_218/v1_1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-nist-800_218-v1_1",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "SP 800-218 - Secure Software Development Framework (SSDF) Version 1.1:",
   "author": "team@zerobias.com",
   "license": "ISC",
@@ -25,7 +25,8 @@
   "zerobias": {
     "package": "nist.800_218.v1_1.framework",
     "import-artifact": "framework",
-    "dataloader-version": "1.0.0"
+    "dataloader-version": "1.0.0",
+    "deprecated": true
   },
   "dependencies": {
     "@zerobias-org/suite-nist-800_218": "latest"

--- a/package/nist/csf/v2/gate-stamp.json
+++ b/package/nist/csf/v2/gate-stamp.json
@@ -1,6 +1,6 @@
 {
-  "version": "2.0.0-uat.0",
-  "branch": "chore/migrate-batch-2",
+  "version": "2.0.1-uat.0",
+  "branch": "chore/deprecate-old-dupes",
   "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "tasks": {

--- a/package/nist/csf/v2/package.json
+++ b/package/nist/csf/v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-nist-csf-v2",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Cybersecurity Framework (CSF) 2.0",
   "author": "team@zerobias.com",
   "license": "ISC",
@@ -25,7 +25,8 @@
   "zerobias": {
     "package": "nist.csf.v2.framework",
     "import-artifact": "framework",
-    "dataloader-version": "1.0.0"
+    "dataloader-version": "1.0.0",
+    "deprecated": true
   },
   "dependencies": {
     "@zerobias-org/suite-nist-csf": "latest"

--- a/package/tisax/isa/v6_0_3/gate-stamp.json
+++ b/package/tisax/isa/v6_0_3/gate-stamp.json
@@ -1,6 +1,6 @@
 {
-  "version": "2.0.0-uat.0",
-  "branch": "chore/migrate-batch-2",
+  "version": "2.0.1-uat.0",
+  "branch": "chore/deprecate-old-dupes",
   "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "tasks": {

--- a/package/tisax/isa/v6_0_3/package.json
+++ b/package/tisax/isa/v6_0_3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-tisax-isa-v6_0_3",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "TISAX ISA",
   "author": "team@zerobias.com",
   "license": "ISC",
@@ -25,7 +25,8 @@
   "zerobias": {
     "package": "tisax.isa.v6_0_3.framework",
     "import-artifact": "framework",
-    "dataloader-version": "1.0.0"
+    "dataloader-version": "1.0.0",
+    "deprecated": true
   },
   "dependencies": {
     "@zerobias-org/suite-tisax-isa": "latest"

--- a/package/us_ny/dfs/2023/gate-stamp.json
+++ b/package/us_ny/dfs/2023/gate-stamp.json
@@ -1,6 +1,6 @@
 {
-  "version": "2.0.0-uat.0",
-  "branch": "chore/migrate-batch-3",
+  "version": "2.0.1-uat.0",
+  "branch": "chore/deprecate-old-dupes",
   "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "tasks": {

--- a/package/us_ny/dfs/2023/package.json
+++ b/package/us_ny/dfs/2023/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-us_ny-dfs-2023",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Cybersecurity Requirements for Financial Services Companies (DFS 23 NYCRR500) - 2023 Amendment 2",
   "author": "team@zerobias.com",
   "license": "ISC",
@@ -25,7 +25,8 @@
   "zerobias": {
     "package": "us_ny.dfs.2023.framework",
     "import-artifact": "framework",
-    "dataloader-version": "1.0.0"
+    "dataloader-version": "1.0.0",
+    "deprecated": true
   },
   "dependencies": {
     "@zerobias-org/suite-us_ny-dfs": "latest"


### PR DESCRIPTION
Per platform rule (Kevin): **`zerobias-org/framework` = OPEN _and_ NEW only**; anything OLD (or closed) belongs in `auditlogic`. These 8 frameworks originated in auditlogic (2024–early 2025) and were bulk-copied into org in Sept 2025 — they're **OLD**, so they don't belong here even though several are public standards.

**Step 1 of 2: deprecate.** Sets `zerobias.deprecated: true` (dataloader → status **Retired**) + patch bump so the retirement republishes; gate-stamps refreshed. Hard-delete follows once the few dependent crosswalk refs are re-pointed.

| Framework | code | npm before |
|---|---|---|
| IEC 60601 2021 | `iec.60601.2021` | 2.0.0 |
| ISO 42001 2023 | `iso.42001.2023` | 2.0.0 |
| NIST CSF v2 | `nist.csf.v2` | 2.0.0 |
| TISAX ISA v6.0.3 | `tisax.isa.v6_0_3` | 2.0.0 |
| US NY DFS 2023 | `us_ny.dfs.2023` | 2.0.0 |
| NIST 800-171 rev2 | `nist.800-171.rev2` | 2.0.0 |
| NIST 800-171 rev3 | `nist.800-171.rev3` | 2.0.0 |
| NIST 800-218 v1.1 | `nist.800_218.v1_1` | 2.0.0 |

**Dependency-safety (validated):** `CrosswalkIndexFileHandler` resolves `sourceStandard`/`targetStandard` via `standardDao.getByPackage()`, which errors only if the standard is **absent**. A Retired framework stays in the catalog, so all crosswalk / compliance-feature references still resolve. Deprecation does not cascade or re-process dependents — **nothing breaks.**

⚠️ **For the eventual hard-delete:** the 6 same-code frameworks keep resolving via the identical-code auditlogic copy, but the 3 divergent NIST codes (`nist.800-171.rev2/rev3`, `nist.800_218.v1_1`) are referenced by ~2 crosswalks each under the org spelling and must be re-pointed to the auditlogic codes first.

Note: `adobe.ccf.v5` was a reported duplicate too but is untracked/unpublished in this repo — excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)