### PR TITLE
chore: drop root workspaces + align settings.gradle.kts with org/module

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,6 @@
   "type": "module",
   "description": "Zerobias framework artifacts",
   "main": "main.js",
-  "workspaces": [
-    "package/**"
-  ],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"
   },

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,10 +1,14 @@
+// settings.gradle.kts — framework monorepo
+//
+// Plugin resolution order: mavenLocal (for `publishToMavenLocal` dev builds
+// of build-tools) → GitHub Packages Maven → gradle plugin portal → mavenCentral.
+// Never via `includeBuild` of a sibling repo path: dev iteration goes through
+// `./gradlew publishToMavenLocal` from build-tools so CI and local resolve
+// the artifact the same way.
+
 pluginManagement {
-    // Use local build-tools if available (dev), otherwise pull from GitHub Packages Maven (CI)
-    val localBuildTools = file("../util/packages/build-tools")
-    if (localBuildTools.exists()) {
-        includeBuild(localBuildTools)
-    }
     repositories {
+        mavenLocal()
         maven {
             url = uri("https://maven.pkg.github.com/zerobias-org/util")
             credentials {


### PR DESCRIPTION
## Summary

Two cleanups Chris flagged in Slack, applied per the template merged at zerobias-org/vendor#71.

- **Root `package.json`**: remove `"workspaces": ["package/**"]`. Hoisted root install was blocking per-package `package-lock.json` files; the publish flow checks for them and runs `npm shrinkwrap` before publishing.
- **`settings.gradle.kts`**: align `pluginManagement` with [`org/module`](https://github.com/zerobias-org/module/blob/main/settings.gradle.kts). Drop `includeBuild("../util/packages/build-tools")` (sibling-path resolution) and resolve via `mavenLocal -> maven pkg -> portal -> mavenCentral`. Dev iteration goes through `./gradlew publishToMavenLocal` from build-tools so CI and local resolve the artifact the same way. Repo-specific bits (`rootProject.name`, plugin set, auto-discover comment) preserved.

`[skip ci]` since no `package/**/build.gradle.kts` changed.

## Test plan

- [x] `./gradlew projectPaths` still resolves all projects after the change
- [ ] Verify the `publish.yml` workflow's `detect` job correctly skips (no package builds changed)

Generated with [Claude Code](https://claude.com/claude-code)
