### PR TITLE
docs: add SCF attribution notice (CC BY-ND 4.0)

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,40 @@
+# Content Attribution Notices
+
+The framework packages in this repository reproduce compliance content whose
+source material is owned by third parties and used under their published
+licenses. This file records the attribution those licenses require. It travels
+with the repository; the same notices apply to the npm packages published
+from it.
+
+The `"license"` field in each package's `package.json` describes the packaging
+and build scaffolding, not the framework content. The content licenses below
+govern the substantive framework data.
+
+---
+
+## Secure Controls Framework (SCF)
+
+**Applies to:** every package under `package/scf/scf/`.
+
+These packages reproduce the **Secure Controls Framework (SCF)** control
+catalog — control identifiers, names, descriptions, and associated metadata —
+published by the Secure Controls Framework Council, LLC.
+
+- **Source:** [Secure Controls Framework](https://securecontrolsframework.com/) —
+  the officially distributed SCF spreadsheet
+  ([securecontrolsframework/securecontrolsframework](https://github.com/securecontrolsframework/securecontrolsframework))
+- **Copyright:** © Secure Controls Framework Council, LLC
+- **License:** [Creative Commons Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)](https://creativecommons.org/licenses/by-nd/4.0/)
+- **Changes:** the control catalog has been converted from the officially
+  distributed spreadsheet format into YAML for machine consumption. The
+  control content itself is reproduced verbatim and unmodified. No controls
+  have been added, removed, or edited.
+
+SCF controls are used in this solution. This repository and the ZeroBias
+platform are not endorsed by, affiliated with, or sponsored by the Secure
+Controls Framework Council, LLC.
+
+Per the CC BY-ND 4.0 license, this content may be redistributed verbatim with
+this attribution, but modified or derivative versions of the SCF content may
+not be distributed. Do not edit the control content of these packages;
+regenerate them from the officially published SCF spreadsheet instead.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 ZeroBias compliance framework artifacts. Each `package/<authority>/<framework>/<version>/` directory is one publishable framework package (e.g. `cis/csc/v8_1`, `nist/800_207/v1`).
 
+## Content licensing & attribution
+
+Framework content reproduced from third-party sources is used under those sources' published licenses — see **[NOTICE.md](NOTICE.md)** for the required attributions. In particular, the SCF packages (`package/scf/scf/*`) are [CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0/) content: redistribute verbatim with attribution; never distribute modified versions of the control content. The `"license"` field in each `package.json` covers packaging/scaffolding only, not the framework content.
+
 ## Authentication
 
 Set `ZB_TOKEN` in your environment to authenticate with the npm registry. Get one from [ZeroBias](https://app.zerobias.com).


### PR DESCRIPTION
## Why

The 9 `package/scf/scf/*` framework packages reproduce the Secure Controls Framework control catalog. Licensing re-review (2026-07-09) confirmed all SCF content — including the STRM mappings — is distributed under **CC BY-ND 4.0** (verified against [SCF T&C](https://securecontrolsframework.com/terms-conditions/), the [official GitHub distribution](https://github.com/securecontrolsframework/securecontrolsframework), and the published STRM documents). Verbatim redistribution, including commercial, is expressly permitted — **but the BY clause requires attribution** (credit + license link + statement of changes), which the repo did not carry until now. SCF's own guidance blesses exactly our use case: *"attribution is as simple as stating SCF controls are used in the solution, such as a GRC platform that includes SCF content."*

## What

- **NOTICE.md** — required SCF attribution: source, copyright, CC BY-ND 4.0 link, changes statement (spreadsheet→YAML format shift, content verbatim/unmodified), no-endorsement disclaimer, and a warning to never distribute *modified* SCF content (ND clause).
- **README.md** — short "Content licensing & attribution" section pointing at NOTICE.md.

## Deliberately out of scope

- Per-package `license` metadata fix (currently misstated as `ISC`): editing 9+ `package.json` files would invalidate every committed gate stamp and force a mass republish. It rides along with each package's next content bump instead.
- Attribution for the other CC-BY sources flagged in LICENSING_REVIEW.md (EU/ES reuse, AU/NZ, CNCF, CoSAI) — NOTICE.md is structured so those can be appended as follow-ups.

No package directories touched → no publishes triggered.