### PR TITLE
feat(nist): add missing elements to public 800-218 + 800-53

### DIFF
--- a/package/nist/800-53/v5/elements/sc-49.yml
+++ b/package/nist/800-53/v5/elements/sc-49.yml
@@ -1,0 +1,5 @@
+id: 3e1597a2-e1bf-466a-8193-409ef61702f8
+externalId: SC-49
+name: 'Hardware-enforced Separation and Policy Enforcement'
+description: '"Implement hardware-enforced separation and policy enforcement mechanisms between [Assignment: organization-defined security domains]."'
+elementType: control

--- a/package/nist/800-53/v5/elements/sc-50.yml
+++ b/package/nist/800-53/v5/elements/sc-50.yml
@@ -1,0 +1,5 @@
+id: c2112e23-bb3e-4e4a-a8a5-f2705c58deff
+externalId: SC-50
+name: 'Software-enforced Separation and Policy Enforcement'
+description: '"Implement software-enforced separation and policy enforcement mechanisms between [Assignment: organization-defined security domains]."'
+elementType: control

--- a/package/nist/800-53/v5/elements/sc-51.yml
+++ b/package/nist/800-53/v5/elements/sc-51.yml
@@ -1,0 +1,5 @@
+id: 6d327d5e-bb26-4d23-9c11-55a70e57d19d
+externalId: SC-51
+name: 'Hardware-based Protection'
+description: '|- a. Employ hardware-based, write-protect for [Assignment: organization-defined system firmware components]; and b. Implement specific procedures for [Assignment: organization-defined authorized individuals] to manually disable hardware write-protect for firmware modifications and re-enable the write-protect prior to returning to operational mode.'
+elementType: control

--- a/package/nist/800-53/v5/elements/si-21.yml
+++ b/package/nist/800-53/v5/elements/si-21.yml
@@ -1,0 +1,5 @@
+id: a507b502-6f77-47b2-9af2-0d99c22196a7
+externalId: SI-21
+name: 'Information Refresh'
+description: '"Refresh [Assignment: organization-defined information] at [Assignment: organization-defined frequencies] or generate the information on demand and delete the information when no longer needed."'
+elementType: control

--- a/package/nist/800-53/v5/elements/si-22.yml
+++ b/package/nist/800-53/v5/elements/si-22.yml
@@ -1,0 +1,5 @@
+id: 9354b2ba-3e21-4f4a-89ac-74b9339e78cb
+externalId: SI-22
+name: 'Information Diversity'
+description: '|- a. Identify the following alternative sources of information for [Assignment: organization-defined essential functions and services]: [Assignment: organization-defined alternative information sources]; and b. Use an alternative information source for the execution of essential functions or services on [Assignment: organization-defined systems or system components] when the primary source of information is corrupted or unavailable.'
+elementType: control

--- a/package/nist/800-53/v5/elements/si-23.yml
+++ b/package/nist/800-53/v5/elements/si-23.yml
@@ -1,0 +1,5 @@
+id: a06748af-a68b-4361-9d47-e60df1864238
+externalId: SI-23
+name: 'Information Fragmentation'
+description: '|- Based on [Assignment: organization-defined circumstances]: a. Fragment the following information: [Assignment: organization-defined information]; and b. Distribute the fragmented information across the following systems or system components: [Assignment: organization-defined systems or system components].'
+elementType: control

--- a/package/nist/800-53/v5/gate-stamp.json
+++ b/package/nist/800-53/v5/gate-stamp.json
@@ -1,7 +1,7 @@
 {
-  "version": "2.0.0-uat.0",
-  "branch": "chore/migrate-batch-2",
-  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "version": "2.1.0-uat.0",
+  "branch": "feat/nist-add-missing-elements",
+  "sourceHash": "66985e7d43130e1356ba18a1e85e9c55997b1d2fefcf838a9c7c322df19b6fac",
   "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "tasks": {
     "validate": "passed",

--- a/package/nist/800-53/v5/package.json
+++ b/package/nist/800-53/v5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-nist-800-53-v5",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "NIST SP 800-53 R5 - Security and Privacy Controls for Information Systems and Organizations",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/nist/800_218/v1_1/elements/po_1_3.yml
+++ b/package/nist/800_218/v1_1/elements/po_1_3.yml
@@ -1,0 +1,5 @@
+id: 5b1e2b47-8ca1-44a2-8186-d008f887db2c
+externalId: PO.1.3
+name: PO.1.3
+description: Communicate requirements to all third parties who will provide commercial software components to the organization for reuse by the organization’s own software. [Formerly PW.3.1]
+elementType: control

--- a/package/nist/800_218/v1_1/gate-stamp.json
+++ b/package/nist/800_218/v1_1/gate-stamp.json
@@ -1,7 +1,7 @@
 {
-  "version": "2.0.2-uat.0",
-  "branch": "fix/scf-undeprecate-7-frameworks",
-  "sourceHash": "8ae481b2503800129345614e364096b19923e3e496e0a6f7b31c42fd707051f2",
+  "version": "2.1.0-uat.0",
+  "branch": "feat/nist-add-missing-elements",
+  "sourceHash": "ff57f200d5f6c331e826360d6d31cca7f55ef4efd2f0e833f217421eb438e137",
   "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "tasks": {
     "validate": "passed",

--- a/package/nist/800_218/v1_1/package.json
+++ b/package/nist/800_218/v1_1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/framework-nist-800_218-v1_1",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "SP 800-218 - Secure Software Development Framework (SSDF) Version 1.1:",
   "author": "team@zerobias.com",
   "license": "ISC",


### PR DESCRIPTION
## Why (licensing review step 5 — NIST option B)

The last 5 public crosswalks depending on `@auditlogic` reference the **duplicate** NIST framework variants (`nist.800218.v1_1` / `nist.80053.rev5`). Rather than importing those duplicates into the public repo (option A), we consolidate onto the existing public artifacts — which were missing 7 elements the crosswalks reference.

## Source-of-truth validation (each element)

- **PO.1.3** (800-218 v1.1): genuine SSDF task under PO.1 — *"Communicate requirements to all third parties who will provide commercial software components…"* `[Formerly PW.3.1]` — verified against the [NIST SP 800-218 PDF](https://nvlpubs.nist.gov/nistpubs/specialpublications/nist.sp.800-218.pdf) + [Chainguard SSDF table](https://edu.chainguard.dev/software-security/secure-software-development/ssdf/)
- **SC-49/50/51** (Hardware/Software-enforced Separation, Hardware-based Protection) + **SI-21/22/23** (Information Refresh/Diversity/Fragmentation): all verified real Rev 5 controls via CSRC + [csf.tools](https://csf.tools/reference/nist-sp-800-53/r5/si/si-21/) — titles/text match the loaded auditlogic variant verbatim
- SC-23(1)/(3) turned out to be a false positive (already present — trailing-underscore naming); untouched

Content is US government work — **public domain (17 U.S.C. §105)**, no license concern.

## Gates

- `800_218/v1_1` → 2.1.0: **full gate + dataloader load green** (element inserted cleanly)
- `800-53/v5` → 2.1.0: structural gate + stamp; the local full load ran 1h50m out-of-region and died with ECONNRESET (known long-load limitation — the content itself passed validation and 6 small inserts are low-risk; can be bastion-verified post-merge via /load-content-to-neon if desired)

## Next

Companion PR repoints the 5 crosswalks (deps + source/targetStandard → public artifact codes). After that: **zero `@auditlogic` deps anywhere in public repos** — step 5 complete.