### PR TITLE
fix(scf): stamp 2026.2 over tracked content, stage before gating in daily-update

### DIFF
--- a/.github/workflows/daily-update.yml
+++ b/.github/workflows/daily-update.yml
@@ -165,6 +165,12 @@ jobs:
               printf 'plugins { id("zb.content") }\n' > "$pkg/build.gradle.kts"
               echo "Added gradle marker to new package: $pkg"
             fi
+            # Stage BEFORE gating. writeGateStamp computes sourceHash over
+            # git-tracked files, so gating a brand-new (untracked) package
+            # yields sha256("") — a stamp that passes locally and is then
+            # rejected by the publish preflight as "source-hash-changed".
+            # Cost a failed 2026.2 publish in run 30499714658.
+            git add -A "$pkg"
             proj=$(echo "${pkg#package/}" | tr '/' ':')
             gate_targets="$gate_targets :$proj:gate"
           done

--- a/package/scf/scf/2026.2/gate-stamp.json
+++ b/package/scf/scf/2026.2/gate-stamp.json
@@ -1,7 +1,7 @@
 {
-  "version": "1.0.0-uat.0",
-  "branch": "feat/scf-update-vendor-migration",
-  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "version": "1.0.0",
+  "branch": "main",
+  "sourceHash": "1b00ce2210ebc57ffe2d2c1b64aa18fb0f6add946b6de02bb65180deb33dc2d3",
   "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "tasks": {
     "validate": "passed",


### PR DESCRIPTION
Follow-up to #232. The `scf/scf/2026.2` publish failed in [run 30499714658](https://github.com/zerobias-org/framework/actions/runs/30499714658) — the only one of ten packages to fail:

```
Gate stamp invalid — source-hash-changed
gate-stamp.json is missing or invalid — run zbb gate locally and commit the stamp before publishing
```

## Cause

`writeGateStamp` computes `sourceHash` over **git-tracked** files. 2026.2 was brand new and still untracked when it was gated, so the stamp recorded the hash of nothing:

```
sourceHash: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
testHash:   e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
```

That value is `sha256("")` — byte-identical to the empty `testHash` beside it, which is the tell. The nine pre-existing packages were already tracked, so they stamped and published fine.

Re-gating with the files tracked gives the real hash:

```
sourceHash: 1b00ce2210ebc57ffe2d2c1b64aa18fb0f6add946b6de02bb65180deb33dc2d3
```

## Also fixes the recurrence

`daily-update.yml` had the same latent bug — it gates changed packages in one step and only runs `git add .` two steps later. **Every brand-new SCF version it generated would have failed publish exactly this way**, which is why this went unnoticed: the automation has not successfully produced a new version since the gradle migration. Each package is now staged before gating.

## Worth fixing upstream

In `build-tools`, a stamp whose `sourceHash` is the hash of no input should not be written as `passing` — it is indistinguishable from a legitimate stamp until preflight rejects it, and the failure surfaces on `main` after merge rather than locally.

## After merge

`update-bundle` and `sync` were skipped when 2026.2 failed, so the bundle has not picked up any of the ten packages and dev/qa/uat are unsynced. The publish triggered by this merge should carry all of it through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WNjiSeEXQWucRjKRV8xesW