### PR TITLE
chore: rename daily-update workflow to weekly-update

### DIFF
--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -1,8 +1,8 @@
-name: Daily Framework Updates
+name: Weekly Framework Updates
 
 on:
   schedule:
-    # Run weekly at 2 AM UTC
+    # Mondays at 02:00 UTC
     - cron: '0 2 * * 1'
   workflow_dispatch:
     # Allow manual triggering for testing
@@ -17,7 +17,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  daily-update:
+  weekly-update:
     runs-on: ubuntu-latest
     if: github.repository == 'zerobias-org/framework' && (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch')
     
@@ -206,16 +206,16 @@ jobs:
         if: steps.changes.outputs.has_changes == 'true'
         run: |
           # Create a unique branch name that matches PR title format
-          branch_name="daily-framework-updates-$(date +%Y-%m-%d)"
+          branch_name="weekly-framework-updates-$(date +%Y-%m-%d)"
           git checkout -b "$branch_name"
           
           # Add all changes
           git add .
           
           # Create commit message
-          commit_msg="chore: 🤖 daily framework updates
+          commit_msg="chore: 🤖 weekly framework updates
           
-          Automated daily update of framework packages.
+          Automated weekly update of framework packages.
           
           Updated packages:${{ env.UPDATED_PACKAGES }}
           Failed packages:${{ env.FAILED_PACKAGES }}
@@ -238,8 +238,8 @@ jobs:
         run: |
           # Create PR to main (canonical branch on the gradle/zbb pipeline).
           # dev/qa/uat are kept in sync downstream by the publish workflow.
-          pr_title="chore: 🤖 daily framework updates $(date +%Y-%m-%d)"
-          pr_body="Automated daily update of framework packages.
+          pr_title="chore: 🤖 weekly framework updates $(date +%Y-%m-%d)"
+          pr_body="Automated weekly update of framework packages.
 
           ## Summary
           **Updated packages:**
@@ -262,7 +262,7 @@ jobs:
       - name: Update summary
         if: always()
         run: |
-          echo "## Daily Update Summary" >> $GITHUB_STEP_SUMMARY
+          echo "## Weekly Update Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           
           # Successfully updated packages

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,7 @@ Use the skill: `/migrate-packages [<a>/<f>/<v>...]`. See [.claude/skills/migrate
 
 ## "Update" sub-packages
 
-Two packages under `package/<a>/<f>/update/` (`opencre/opencre/update`, `complianceforge/scf/update`) are private utility/fetcher packages that pull upstream content and regenerate the framework yaml. They have `"private": true`, their own `update` npm script (`tsx index.ts`), and do NOT carry a gradle marker — `settings.gradle.kts` skips them. The daily-update workflow (`.github/workflows/daily-update.yml`) is the trigger.
+Two packages under `package/<a>/<f>/update/` (`opencre/opencre/update`, `scf/scf/update`) are private utility/fetcher packages that pull upstream content and regenerate the framework yaml. They have `"private": true`, their own `update` npm script (`tsx index.ts`), and do NOT carry a gradle marker — `settings.gradle.kts` skips them. The weekly-update workflow (`.github/workflows/weekly-update.yml`) is the trigger.
 
 ## Branches
 
@@ -153,7 +153,7 @@ Use `!` for major version bumps. Common scopes: `framework-<...>`, `bundle`, `va
 
 Publish workflow: `.github/workflows/publish.yml` — a thin wrapper around `zerobias-org/devops/.github/workflows/zbb-publish-reusable.yml@main`. Triggered on `push` to main/qa/dev/uat (paths: `package/**`, `.github/workflows/publish.yml`) and on `workflow_dispatch` (optional `framework` input). This is the only publish/version/sync workflow — the legacy nx-era `publish-pull-request.yml` and `pull-request-target.yml` were removed in the cleanup (the reusable workflow owns the full version → publish → sync lifecycle).
 
-The one other workflow is `.github/workflows/daily-update.yml` — the upstream-content fetcher that runs the two private `package/**/update/` packages, gates any regenerated/new framework packages via `./gradlew :<path>:gate`, and opens a PR to `main`. It is not part of the publish pipeline.
+The one other workflow is `.github/workflows/weekly-update.yml` — the upstream-content fetcher that runs the two private `package/**/update/` packages, gates any regenerated/new framework packages via `./gradlew :<path>:gate`, and opens a PR to `main`. It runs Mondays at 02:00 UTC (it was named `daily-update` for a long time while the cron said weekly) and is not part of the publish pipeline.
 
 The reusable workflow's jobs:
 1. **detect** — diff to find changed packages

--- a/package/scf/scf/update/CLAUDE.md
+++ b/package/scf/scf/update/CLAUDE.md
@@ -35,7 +35,7 @@ gate does):
 ./gradlew :scf:scf:<version>:gate
 ```
 
-`.github/workflows/daily-update.yml` runs `npm run update` for every
+`.github/workflows/weekly-update.yml` runs `npm run update` for every
 `package/**/update/` package, then gates each changed framework package and
 opens a PR to `main`.
 


### PR DESCRIPTION
The cron has always been `0 2 * * 1` — Mondays at 02:00 UTC — and the comment beside it even said "Run weekly". Everything else said daily.

| | before | after |
|---|---|---|
| file | `daily-update.yml` | `weekly-update.yml` |
| `name:` | Daily Framework Updates | Weekly Framework Updates |
| job id | `daily-update` | `weekly-update` |
| branch cut | `daily-framework-updates-<date>` | `weekly-framework-updates-<date>` |
| commit + PR title | `🤖 daily framework updates` | `🤖 weekly framework updates` |
| step summary | `## Daily Update Summary` | `## Weekly Update Summary` |

**The cron itself is untouched** — this is naming only.

Also corrects two stale references in the root `CLAUDE.md`: it pointed at the old workflow path, and still listed the fetcher as `complianceforge/scf/update`, which moved to `scf/scf/update` in #232.

## Validation

Triggered the workflow on `main` before renaming — [run 30503291908](https://github.com/zerobias-org/framework/actions/runs/30503291908), **success**. It is working correctly now:

```
Found update script in: package/opencre/opencre/update
Found update script in: package/scf/scf/update          ← finds the moved fetcher
✅ Successfully updated package/opencre/opencre/update    (100 elements)
No new version available. Current: 2026.2, Latest: 2026.2 ← correct version state
Update skipped: No new version available
Gating: :opencre:opencre:v1:gate
```

Two things this confirms:

1. Discovery picks up `package/scf/scf/update` at its new location, and the package still satisfies the `.scripts.update` + `private == true` filter.
2. Version detection now reports **2026.2** as current, matching upstream. Before #232 it reported 2025.4 — 2026.1.1's workbook had never been committed to `cache/` — so it would re-download and regenerate on every run.

For contrast, the last scheduled run before this work ([30233483296](https://github.com/zerobias-org/framework/actions/runs/30233483296), 2026-07-27) failed with:

```
Cannot find module '.../scripts/validate.ts'
  imported from .../package/complianceforge/scf/2026.2/
```

## Note

The validation run opened #234 from the *opencre* fetcher (466 element files, large net deletion). That is unrelated to this PR and unreviewed — flagging rather than merging.

Not addressed here: the workflow retains a vestigial `push: branches: [test]` trigger while the job's `if:` guard only permits `main` or `workflow_dispatch`, so a push to `test` starts the workflow and immediately skips the job. Dead config, easy follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WNjiSeEXQWucRjKRV8xesW