### PR TITLE
docs: add repo LICENSE and extend content attribution to every package

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -29,5 +29,11 @@ terms vary — some are Creative Commons, some are Crown copyright, some
 carry a NoDerivatives or ShareAlike condition — and several are more
 restrictive than this license.
 
-See NOTICE.md for the per-source attribution and license terms. Where the
-two conflict, the source's terms govern the content.
+Each package declares its content's license in the "license" field of its
+package.json. Packages still reading "ISC" are stale rather than
+authoritative and are corrected as each takes its next content bump.
+
+See NOTICE.md for the per-source attribution and license terms. It is
+authoritative for every package regardless of what that package's
+package.json currently says, and where the two conflict, the source's
+terms govern the content.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,33 @@
+ISC License
+
+Copyright (c) 2026 ZeroBias
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+---
+
+SCOPE OF THIS LICENSE
+
+This license covers the repository's own work: the build scaffolding,
+validators, update tooling, scripts, and the structure and schema of the
+framework packages.
+
+It does NOT cover the compliance content those packages reproduce. That
+content is owned by the standards bodies, government agencies, and other
+third parties that published it, and is used under their own terms. Those
+terms vary — some are Creative Commons, some are Crown copyright, some
+carry a NoDerivatives or ShareAlike condition — and several are more
+restrictive than this license.
+
+See NOTICE.md for the per-source attribution and license terms. Where the
+two conflict, the source's terms govern the content.

--- a/LICENSING_REVIEW.md
+++ b/LICENSING_REVIEW.md
@@ -1,0 +1,119 @@
+# Framework Licensing Review — `zerobias-org/framework`
+
+**Repo:** `zerobias-org/framework` · **Scope:** 73 framework packages · **Reviewed:** 7 Jul 2026 · **Updated:** 30 Jul 2026 · **Status:** Draft for review
+
+> **Update, 30 Jul 2026.** All 8 Tier 1 packages were removed in #226 / #225 — that tier is resolved and is kept below for the record. SCF has since grown from 5 versions to 10 (#228 added four legacy versions; 2026.2 was published 30 Jul), and a regeneration on 30 Jul restored the CMM maturity text that earlier packages had been missing, so SCF's volume is materially larger than when this was written. Attribution for SCF and for the CC-BY sources now lives in [NOTICE.md](NOTICE.md); a top-level `LICENSE` was added the same day.
+
+Which compliance-framework packages are safe to ship in a public repository — and which reproduce copyrighted text that isn't ours to redistribute.
+
+> **This is an engineering-side assessment, not legal advice.** The Tier 1 and Tier 2 items should be confirmed with counsel before (or instead of) shipping.
+
+---
+
+## 01 · The bottom line
+
+Most of the catalogue is clean. The risk is concentrated in a short list of packages that reproduce the full requirement text of standards their publishers actively license or sell.
+
+| Count | Category |
+|------:|----------|
+| **49** | Clean — gov works, edicts of law, or CC-BY / CC0 |
+| **8**  | Fix required — restrictive licence **and** full protected text |
+| **10** | Decision needed — NC / ND / share-alike / Crown copyright |
+| **7**  | Already safe — restrictive source, but text was pre-stubbed |
+
+**Why two dimensions per package.** Licensing risk is the product of two things: how restrictive the *source document's* licence is, and whether our package actually *reproduces its protected text*. A proprietary standard we've reduced to bare control IDs is low-risk; an open-but-share-alike standard we've reformatted verbatim can still be a problem. Every verdict below reflects both — the source licence was researched and then checked against the real `elements/*.yml` content.
+
+Someone has already stubbed the ISO, IEC, and several statute packages down to identifiers and "buy a copy" pointers. **Those are safe and should stay stubbed — do not backfill their text.**
+
+---
+
+## 02 · Fix required (8 packages) — RESOLVED
+
+> All eight were removed from this repo and migrated to `@auditlogic` in #226 and #225. Retained here for the record.
+
+Restrictive or proprietary licence, **and** the package reproduces the full title + description text. These should not sit in a public repo in their current form.
+
+| Package | Elements | Licence reality | Verdict |
+|---------|---------:|-----------------|---------|
+| `pci_ssc/dss/v4_0_1` | 351 | PCI SSC Terms of Use — personal/internal use only; publishing, distributing, copying and derivatives all expressly prohibited. Free download ≠ free redistribution. | Prohibited |
+| `cis/csc/v8_1` | 171 | CC BY-**NC-ND** 4.0 — breaches both the NonCommercial clause (commercial platform) and NoDerivatives (restructured into YAML). Commercial use needs prior CIS approval. | Licence breach |
+| `csa/aicm/v1` | 261 | CSA terms — "may not be redistributed"; commercial use gated behind a paid CSA licence. | No redistribution |
+| `aiuc/aiuc_1/v1` | 57 | Proprietary, all rights reserved (AIUC). Terms forbid copying or distributing any part; no open licence at all. | Proprietary |
+| `iso/27001/2022a` | 93 | ISO "all rights reserved" (POCOSA) — reproduces the Annex A control titles and normative "shall" statements. (The other ISO/IEC packages are already stubbed — see Tier 3.) | Copyrighted |
+| `us/nerc/2024` | 204 | NERC asserts copyright over its CIP standards. FERC adoption gives only a *contested* fair-use argument — never held uncopyrightable. | Contested |
+| `sa/sai/v2024` | 81 | Saudi NCA IoT guidance, © NCA — a copyrighted government publication (not a statute), with no reuse grant. | No licence |
+| `uae/niaf/v1` | 15 | TDRA "all rights reserved" — personal, non-commercial use only, no revisions, no redistribution without written consent. | Prohibited |
+
+---
+
+## 03 · Decision needed (10 packages)
+
+Openly licensed or reproducible, but a clause — NonCommercial, NoDerivatives, share-alike, or Crown copyright — collides with either the commercial context or the fact that we reformat the text into a derivative. Verbatim + attribution may be defensible; restructuring likely isn't. A call from legal is warranted.
+
+| Package | Elements | Clause in tension | Note |
+|---------|---------:|-------------------|------|
+| `scf/scf/*` (×10 versions) | 1208–1568 each | CC BY-**ND** 4.0 — no derivatives | **Largest exposure by volume.** Commercial use is fine, but SCF defines derivatives broadly (incl. AI-assisted and restructured content) and gates them behind a paid Licensed Content Provider licence. Covers 2023.3.1, 2024.2, 2024.3, 2024.4, 2025.2.1, 2025.2.2, 2025.3.1, 2025.4, 2026.1.1, 2026.2 — 13,777 elements in total. NOTICE.md now records the CC BY-ND attribution and takes the position that verbatim format conversion is redistribution rather than derivation; that reading still warrants confirmation by counsel. |
+| `owasp/llmtop10/v2025` | 10 | CC BY-**SA** 4.0 — share-alike | Commercial use allowed, but the copyleft attaches to our derivative — it must itself carry CC BY-SA 4.0. |
+| `ca/osfi/v1` | 77 | Canada Crown copyright | Non-commercial reproduction is free with attribution, but adaptation / commercial distribution needs written permission. |
+| `ca/pci/v10_171` | 275 | Canada Crown copyright | Same CCCS / Government of Canada terms as OSFI B-13. |
+| `gb/mds/v2024` | 147 | UK Crown copyright / OGL v3.0 | Likely redistributable with attribution ("Contains public sector information licensed under OGL v3.0"), but the doc carries an ambiguous "MOD internal use" clause — confirm. |
+| `sparta/counter/v1` | 55 | Aerospace Corp — conditional | Authored by an FFRDC, *not* the government. Redistribution allowed only with copyright + licence text + SPARTA® trademark preserved and MITRE ATT&CK terms honoured. |
+
+---
+
+## 04 · Restrictive source, already safe (7 packages)
+
+The source is copyrighted, but these packages were previously reduced to identifiers, clause numbers, or "buy a copy" pointers — no protected text is present. **No action beyond keeping them that way — do not backfill text.**
+
+| Package | State | Source licence |
+|---------|-------|----------------|
+| `iso/27001/2022` | 148 / 152 stubbed | ISO all rights reserved — only clause titles remain |
+| `iso/27002/2022` | fully stubbed | ISO all rights reserved |
+| `iso/42001/2023` | 140 / 144 stubbed | ISO all rights reserved |
+| `iec/60601/2021` | fully stubbed | IEC all rights reserved |
+| `cn/csl/v1` | article-# refs | Copyrighted Stanford/DigiChina translation is **not** reproduced — only article numbers |
+| `sa/pdpl/v1` | article-# refs | Saudi statute; no full text reproduced |
+| `naic/mdl/v1` | "see source" stubs | NAIC © all rights reserved (private nonprofit model law) |
+
+---
+
+## 05 · Clean — no action (49 packages)
+
+Source material is genuinely free to redistribute: US government works (public domain, 17 U.S.C. §105), statutes and regulations (edicts of government, not copyrightable), and explicitly CC-BY / CC0 material. Attribution is a light condition on the CC-BY and EU/Spain items.
+
+| Group | Count | Legal basis | Packages |
+|-------|------:|-------------|----------|
+| NIST publications | 13 | US gov works — public domain (§105) | 800-53 · 800-171 rev2/r3 · 800-171A ×2 · 800-161 · 800-207 · 800-218 · AI 600 · CSF 2.0 · IR 8397 · Label · AI RMF |
+| US federal / regulatory | 14 | Public domain; CISA CPG is explicit CC0 | CISA SSDAF · CISA TIC · CISA CPG · CJIS · SEC rule · DPF · FCA · FDA · GLBA · HICP · HIPAA ×2 · MARS-E · DoD ZTRA |
+| US state law | 5 | Statutes / regs — edicts of government | CA CPRA · NY DFS 500 · OR CPA · TN IPA · TX CDPA |
+| EU & Spain | 9 | EUR-Lex reuse (2011/833/EU) & BOE — attribution required | EU AI Act · CRA · CRA Annex · DORA · ENISA NIS2 ×2 · GDPR · ES BOE · ES Royal Decree |
+| Other national | 5 | CC BY 4.0 / statute exception | AU Essential Eight · AU ISM · NZ HISF ×2 · India DPDPA |
+| Open community | 3 | CC BY 4.0 / CC0 | CNCF SSCP · CoSAI MCP Security · OpenCRE |
+
+**Attribution caveat inside the clean set:** `nist/csf/v2` content is public domain, but the "NIST Cybersecurity Framework" name and logo are protected marks — reference them nominatively, never in a way implying NIST endorsement.
+
+---
+
+## 06 · Other findings & housekeeping
+
+- **Package metadata misstates the licence.** 73 of 75 `package.json` files declare `"license": "ISC"` (`owasp/asvs` and `owasp/samm` correctly declare `CC-BY-SA-4.0`). That's the npm-package field, but it misrepresents content that is actually CC-BY, Crown copyright, or proprietary — and it doesn't satisfy the attribution obligations the CC-BY sources (EU, Spain, AU, NZ, CNCF, CoSAI) carry. Consider a dedicated content-licence / source-attribution field per package.
+- ~~**No top-level `LICENSE` file** exists in the repo.~~ Added 30 Jul 2026, scoped to the repository's own tooling and schema with the content terms delegated to `NOTICE.md`.
+- **`adobe/ccf/v5` is an empty scaffold** — no `index.yml`, zero elements, so no current exposure. Note for later: its source (Adobe CCF) is CC BY-**NC**-SA 4.0, so the NC clause would bite if anyone populates it.
+- **Duplicate sources** (not a licensing issue, but worth reconciling): `eu/enisa/v1` ≡ `eu/enisa/annex`; `es/boe/v2022` ≡ `es/royaldecree/2022`; `nz/hisf/v1` ≡ `nz/hisf/suppliers`.
+- **EU CRA is the proposal text** (COM(2022) 454), not the final adopted Regulation (EU) 2024/2847 — confirm which we intend to ship.
+
+---
+
+## 07 · Recommended remediation
+
+The pattern already applied to ISO/IEC is the template for the rest.
+
+- **For Tier 1 (and the ND / Crown-copyright items in Tier 2):** store only our own control identifiers, codes, and numbering, plus a link to the official source, and stub the copyrighted title/description text. Bare identifiers ("Requirement 8.3.6", "CIS Control 4.1") are facts with thin-to-no copyright protection; the exposure lives entirely in the reproduced titles and narrative descriptions.
+- **Where full text is a product requirement:** a paid licence unlocks it cleanly — a CIS commercial approval, an SCF Licensed Content Provider licence, or a CSA licence. ISO/IEC and PCI require a separate written agreement.
+- **Across the clean set:** add the attribution notices the CC-BY and EU/Spain reuse terms require, so those stay compliant as the catalogue grows.
+
+---
+
+## Method
+
+Each package's source document was researched for its copyright/licence terms, then cross-checked against the actual `elements/*.yml` content to confirm whether protected text is genuinely reproduced. Verdicts reflect both. This is an engineering-side assessment, not legal advice — the Tier 1 and Tier 2 items should be confirmed with counsel before or instead of shipping.

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -6,9 +6,13 @@ licenses. This file records the attribution those licenses require. It travels
 with the repository; the same notices apply to the npm packages published
 from it.
 
-The `"license"` field in each package's `package.json` describes the packaging
-and build scaffolding, not the framework content. The content licenses below
-govern the substantive framework data.
+Each package declares its content's license in the standard `"license"` field
+of `package.json` — for example `CC-BY-ND-4.0` on the SCF packages and
+`CC-BY-SA-4.0` on the OWASP ones. Where a package still reads `ISC`, that value
+is stale rather than authoritative: it describes only the packaging scaffolding
+and predates this convention, and it is being corrected package by package as
+each takes its next content bump. **The sections below are authoritative for
+every package, whatever its `package.json` currently says.**
 
 ---
 
@@ -132,9 +136,9 @@ endorse this repository or the ZeroBias platform.
   OWASP requirement numbering preserved
 
 **Share-alike:** CC BY-SA 4.0 is a copyleft license. Adaptations of this content
-must themselves be distributed under CC BY-SA 4.0 — the ISC license declared in
-`package.json` covers the packaging scaffolding only and does not relicense the
-OWASP content.
+must themselves be distributed under CC BY-SA 4.0. `owasp/asvs` and `owasp/samm`
+already declare `CC-BY-SA-4.0` in `package.json`; `owasp/llmtop10` still reads
+`ISC` and should be corrected at its next content bump.
 
 ---
 

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -38,3 +38,208 @@ Per the CC BY-ND 4.0 license, this content may be redistributed verbatim with
 this attribution, but modified or derivative versions of the SCF content may
 not be distributed. Do not edit the control content of these packages;
 regenerate them from the officially published SCF spreadsheet instead.
+
+---
+
+## European Union legislation
+
+**Applies to:** `package/eu/ai/v2024`, `package/eu/cra/v1`, `package/eu/cra_annex/v1`,
+`package/eu/dora/2023`, `package/eu/enisa/v1`, `package/eu/enisa/annex`,
+`package/eu/gdpr/v1`.
+
+These packages reproduce requirement text from EU regulations and Commission
+documents published via EUR-Lex.
+
+- **Source:** [EUR-Lex](https://eur-lex.europa.eu/) — the official EU law portal
+- **Copyright:** © European Union, 1998–2026
+- **Reuse:** permitted for commercial and non-commercial purposes under
+  [Commission Decision 2011/833/EU](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32011D0833),
+  subject to acknowledging the source and indicating changes
+- **Changes:** requirement text has been extracted from the published documents
+  and restructured into YAML elements for machine consumption. Article and
+  recital numbering is preserved.
+
+Reuse of EU legal texts does not imply endorsement by the European Union, and
+the Commission is not liable for any consequence of their reuse.
+
+---
+
+## Spain — Boletín Oficial del Estado (BOE)
+
+**Applies to:** `package/es/boe/v2022`, `package/es/royaldecree/2022`.
+
+- **Source:** [Agencia Estatal Boletín Oficial del Estado](https://www.boe.es/) —
+  BOE-A-2022-7191 (Real Decreto 311/2022, Esquema Nacional de Seguridad)
+- **Copyright:** © Agencia Estatal Boletín Oficial del Estado
+- **Basis:** Spanish legal texts published in the BOE; reused with attribution
+  to the official source
+- **Changes:** article text extracted and restructured into YAML elements;
+  article numbering preserved
+
+---
+
+## Australia — Australian Signals Directorate / ACSC
+
+**Applies to:** `package/au/aee/v1` (Essential Eight),
+`package/au/ism/v1` (Information Security Manual).
+
+- **Source:** [Australian Cyber Security Centre](https://www.cyber.gov.au/)
+- **Copyright:** © Commonwealth of Australia
+- **License:** [Creative Commons Attribution 4.0 International (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/)
+- **Changes:** control and mitigation text extracted and restructured into YAML
+  elements for machine consumption
+
+This material is used under CC BY 4.0. The Commonwealth of Australia does not
+endorse this repository or the ZeroBias platform.
+
+---
+
+## New Zealand — Te Whatu Ora
+
+**Applies to:** `package/nz/hisf/v1`, `package/nz/hisf/suppliers`.
+
+- **Source:** [Health Information Security Framework](https://www.tewhatuora.govt.nz/) —
+  Te Whatu Ora | Health New Zealand
+- **Copyright:** © Te Whatu Ora — Health New Zealand
+- **License:** [Creative Commons Attribution 4.0 International (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/),
+  consistent with the NZGOAL open-access framework
+- **Changes:** requirement text extracted and restructured into YAML elements
+
+---
+
+## India — Digital Personal Data Protection Act, 2023
+
+**Applies to:** `package/in/dpdpa/2023`.
+
+- **Source:** [Ministry of Electronics & Information Technology](https://www.meity.gov.in/) —
+  the Digital Personal Data Protection Act, 2023
+- **Basis:** statutory text (an edict of government); section numbering preserved
+- **Changes:** section text extracted and restructured into YAML elements
+
+---
+
+## OWASP
+
+**Applies to:** `package/owasp/asvs/v4.0.3`, `package/owasp/samm/v1.0`,
+`package/owasp/llmtop10/v2025`.
+
+- **Source:** [OWASP Foundation](https://owasp.org/) — Application Security
+  Verification Standard, Software Assurance Maturity Model, and Top 10 for
+  Large Language Model Applications
+- **Copyright:** © The OWASP Foundation
+- **License:** [Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)](https://creativecommons.org/licenses/by-sa/4.0/)
+- **Changes:** requirement text extracted and restructured into YAML elements;
+  OWASP requirement numbering preserved
+
+**Share-alike:** CC BY-SA 4.0 is a copyleft license. Adaptations of this content
+must themselves be distributed under CC BY-SA 4.0 — the ISC license declared in
+`package.json` covers the packaging scaffolding only and does not relicense the
+OWASP content.
+
+---
+
+## CNCF — Software Supply Chain Best Practices
+
+**Applies to:** `package/cncf/sscp/v1`.
+
+- **Source:** [CNCF TAG Security](https://tag-security.cncf.io/community/working-groups/supply-chain-security/supply-chain-security-paper/)
+- **Copyright:** © The Linux Foundation / CNCF
+- **License:** [Creative Commons Attribution 4.0 International (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/)
+- **Changes:** practice text extracted and restructured into YAML elements
+
+---
+
+## CoSAI / OASIS — MCP Security
+
+**Applies to:** `package/oasisopen/cosai/mcp_security`.
+
+- **Source:** [CoSAI Workstream 4 — Secure Design for Agentic Systems](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems)
+- **Copyright:** © OASIS Open / Coalition for Secure AI contributors
+- **License:** [Creative Commons Attribution 4.0 International (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/)
+- **Changes:** guidance text extracted and restructured into YAML elements
+
+---
+
+## OpenCRE
+
+**Applies to:** `package/opencre/opencre/v1`.
+
+- **Source:** [OpenCRE — Open Common Requirement Enumeration](https://opencre.org/)
+- **Copyright:** © OWASP Foundation / OpenCRE contributors
+- **License:** [Creative Commons Attribution 4.0 International (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/)
+- **Changes:** common requirement entries fetched from the OpenCRE API and
+  restructured into YAML elements; CRE identifiers preserved
+
+---
+
+## United States federal and state government works
+
+**Applies to:** the NIST, CISA, HHS/HIPAA, CMS, DoD, SEC, FDA and US state-law
+packages under `package/nist/`, `package/cisa/`, `package/us/`, `package/dod/`
+and `package/us_*/`.
+
+Works of the United States federal government are not subject to copyright
+within the United States (17 U.S.C. § 105), and statutes and regulations are
+edicts of government. No attribution is legally required; the source is recorded
+in each package's `index.yml` `url` field.
+
+**Trademark note:** although NIST publications are in the public domain, the
+NIST name and the "NIST Cybersecurity Framework" mark are protected. Reference
+them nominatively only; nothing here implies NIST endorsement.
+
+---
+
+## Sources requiring confirmation before further distribution
+
+The following packages reproduce content whose terms are more restrictive than
+the sections above, or ambiguous enough to need a considered call. They are
+recorded here for visibility. **Confirm the position with counsel before relying
+on these packages in a commercial distribution.**
+
+| Package | Source | Term in tension |
+|---|---|---|
+| `package/ca/osfi/v1` | OSFI Guideline B-13 | Canada Crown copyright — non-commercial reproduction is free with attribution; adaptation or commercial distribution needs written permission |
+| `package/ca/pci/v10_171` | Canadian Centre for Cyber Security ITSP.10.171 | Canada Crown copyright — same terms as above |
+| `package/gb/mds/v2024` | UK MOD DEF STAN 05-138 Issue 4 | UK Crown copyright; likely reusable under [OGL v3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/) with attribution, but the document carries an ambiguous internal-use clause |
+| `package/sparta/counter/v1` | The Aerospace Corporation — SPARTA | Authored by an FFRDC, not the US government, so § 105 does not apply. Redistribution requires preserving the copyright notice, license text and SPARTA® trademark, and honouring MITRE ATT&CK terms |
+
+Where UK Crown material is redistributed under OGL v3.0, the required notice is:
+"Contains public sector information licensed under the Open Government Licence
+v3.0."
+
+---
+
+## Deliberately stubbed — do not backfill
+
+**Applies to:** `package/iso/27001/2022`, `package/iso/27002/2022`,
+`package/iso/42001/2023`, `package/iec/60601/2021`, `package/cn/csl/v1`,
+`package/sa/pdpl/v1`, `package/naic/mdl/v1`.
+
+These sources are copyrighted and are **not** licensed for redistribution. The
+packages therefore carry only what is not protected — control identifiers,
+clause numbers and titles — with the description field reduced to a pointer at
+the official source (for example, *"Buy a copy of ISO 27001 for control
+content"*). No requirement text is reproduced, so no attribution is owed and
+no license is breached.
+
+**This state is intentional and must be preserved.** Do not populate the
+description fields of these packages from the source documents, whether by hand
+or by an automated fetcher. A well-meaning "the descriptions are empty, let's
+fill them in" is exactly how this protection gets undone — the emptiness is the
+compliance measure, not a gap.
+
+If full text becomes a product requirement, it needs a paid license from the
+publisher (ISO/IEC and NAIC each require a separate written agreement), not a
+regeneration.
+
+---
+
+## Maintaining this file
+
+Add a section whenever a package is added whose source is not a US government
+work or an edict of government. The licensing assessment behind these entries —
+including the packages deliberately reduced to identifiers rather than
+reproducing protected text — is recorded in
+[LICENSING_REVIEW.md](LICENSING_REVIEW.md).
+
+This file records attribution; it is not legal advice.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ ZeroBias compliance framework artifacts. Each `package/<authority>/<framework>/<
 
 ## Content licensing & attribution
 
-Framework content reproduced from third-party sources is used under those sources' published licenses — see **[NOTICE.md](NOTICE.md)** for the required attributions. In particular, the SCF packages (`package/scf/scf/*`) are [CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0/) content: redistribute verbatim with attribution; never distribute modified versions of the control content. The `"license"` field in each `package.json` covers packaging/scaffolding only, not the framework content.
+Framework content reproduced from third-party sources is used under those sources' published licenses — see **[NOTICE.md](NOTICE.md)** for the required attributions. In particular, the SCF packages (`package/scf/scf/*`) are [CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0/) content: redistribute verbatim with attribution; never distribute modified versions of the control content.
+
+Each package declares its content license in the standard `"license"` field of its `package.json`. Packages still reading `ISC` are stale, not authoritative — that value describes only the packaging scaffolding, and is corrected package by package as each takes its next content bump. **NOTICE.md is authoritative for every package regardless of what its `package.json` currently says.**
 
 [**LICENSE**](LICENSE) covers this repository's own work — tooling, validators, scripts, and package structure. It does not extend to the reproduced content, whose terms are recorded in NOTICE.md and, where a source is more restrictive, govern over it. [**LICENSING_REVIEW.md**](LICENSING_REVIEW.md) records the per-package assessment behind those entries, including which packages are deliberately reduced to identifiers rather than reproducing protected text — **do not backfill text into those**.
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ ZeroBias compliance framework artifacts. Each `package/<authority>/<framework>/<
 
 Framework content reproduced from third-party sources is used under those sources' published licenses — see **[NOTICE.md](NOTICE.md)** for the required attributions. In particular, the SCF packages (`package/scf/scf/*`) are [CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0/) content: redistribute verbatim with attribution; never distribute modified versions of the control content. The `"license"` field in each `package.json` covers packaging/scaffolding only, not the framework content.
 
+[**LICENSE**](LICENSE) covers this repository's own work — tooling, validators, scripts, and package structure. It does not extend to the reproduced content, whose terms are recorded in NOTICE.md and, where a source is more restrictive, govern over it. [**LICENSING_REVIEW.md**](LICENSING_REVIEW.md) records the per-package assessment behind those entries, including which packages are deliberately reduced to identifiers rather than reproducing protected text — **do not backfill text into those**.
+
 ## Authentication
 
 Set `ZB_TOKEN` in your environment to authenticate with the npm registry. Get one from [ZeroBias](https://app.zerobias.com).


### PR DESCRIPTION
`NOTICE.md` covered SCF only. The other CC-BY sources carry attribution as a licence **condition**, so those packages were non-compliant while unattributed — on a public repo.

Coverage is now **73/73 packages**.

## Attribution added

| Source family | Packages | Terms |
|---|---:|---|
| EU legislation (EUR-Lex) | 7 | Decision 2011/833/EU · © European Union 1998–2026 |
| Spain (BOE) | 2 | Agencia Estatal BOE |
| Australia (ACSC) | 2 | CC BY 4.0 · © Commonwealth of Australia |
| New Zealand (Te Whatu Ora) | 2 | CC BY 4.0 (NZGOAL) |
| India (DPDPA) | 1 | statutory text |
| OWASP | 3 | CC BY-SA 4.0 — share-alike called out explicitly |
| CNCF | 1 | CC BY 4.0 |
| CoSAI / OASIS | 1 | CC BY 4.0 |
| OpenCRE | 1 | CC BY 4.0 |
| US government | ~32 | 17 U.S.C. § 105 — none owed, recorded anyway |
| SCF | 10 | unchanged, already present |

**Verification:** the EU reuse terms and the ACSC CC BY 4.0 licence were checked against the publishers directly. The rest follow `LICENSING_REVIEW.md`'s research rather than independent re-verification — worth a reviewer's eye, since a notice asserting the wrong licence is worse than none.

## Two sections beyond plain attribution

**Confirm before further distribution** — Canada Crown copyright (OSFI B-13, CCCS ITSP.10.171), UK MOD DEF STAN under OGL v3.0 with an ambiguous internal-use clause, and SPARTA (Aerospace Corp — an FFRDC, so § 105 does *not* apply). Recorded for visibility, not asserted as settled.

**Deliberately stubbed — do not backfill** — the seven ISO / IEC / NAIC / statute packages reduced to identifiers and "buy a copy" pointers. Verified still stubbed: ISO 27001 elements read *"Buy a copy of ISO 27001 for control content"*. The emptiness **is** the compliance measure, not a gap — and today's SCF CMM backfill is exactly the reflex that would undo it, which is why it's written down rather than assumed.

## LICENSE

The repo had none. Scoped explicitly to this repository's own work — tooling, validators, scripts, package structure — with content terms delegated to `NOTICE.md` and the source's terms governing on conflict.

Sibling repos (`vendor`, `suite`, `product`, `tag`) have neither `LICENSE` nor `NOTICE`. Worth propagating.

## LICENSING_REVIEW.md

Lands from its branch, where it had sat unmerged since 7 Jul, refreshed:

- Tier 1 marked **RESOLVED** — all 8 packages removed in #226 / #225
- SCF corrected: ×5 versions → **×10**, 13,777 elements
- Counts corrected: 74 → 73 packages, 221 → 75 `package.json` files

## Not in scope

Per-package `"license": "ISC"` is still uncorrected. #229 deliberately deferred that to each package's next content bump, to avoid invalidating every committed gate stamp at once; this change keeps to that decision. Nine SCF packages took a content bump today without it, so the deferral is slipping — worth its own PR.

**Docs-only:** no package touched, no gate stamp invalidated, nothing republished.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WNjiSeEXQWucRjKRV8xesW